### PR TITLE
Option.none_()

### DIFF
--- a/core/src/main/fj/data/Option.java
+++ b/core/src/main/fj/data/Option.java
@@ -626,6 +626,14 @@ public abstract class Option<A> implements Iterable<A> {
     return new Some<T>(t);
   }
 
+  public static <T> F<T, Option<T>> none_() {
+    return new F<T, Option<T>>() {
+      public Option<T> f(final T t) {
+        return none();
+      }
+    };
+  }
+
   /**
    * Constructs an optional value that has no value.
    *


### PR DESCRIPTION
I've added a `none_()` method to `Option`, for parity with `some_()`.  I had a need for this in [my own code](https://bitbucket.org/alreadythere/porkbelly/src/69e4b3250979/src/main/java/com/mergeconflict/porkbelly/MatcherF.java), where depending on one's level of optimism, one can either declare a "matcher" that matches everything or nothing.
