### PR TITLE
Correct some issues with the SBT build

### DIFF
--- a/core/src/main/java/fj/data/hlist/HPre.java
+++ b/core/src/main/java/fj/data/hlist/HPre.java
@@ -265,7 +265,7 @@ public final class HPre {
      */
     public static <N extends HNat<N>, NN extends HNat<NN>, B extends HBool, E extends HEq<N, NN, B>>
     HEq<HSucc<N>, HSucc<NN>, B> eq(final HSucc<N> a, final HSucc<NN> b, final E e) {
-      return new HEq<HSucc<N>, HSucc<NN>, B>(e.v);
+      return new HEq<HSucc<N>, HSucc<NN>, B>(e.v());
     }
 
   }
@@ -278,6 +278,10 @@ public final class HPre {
 
     private HAdd(final C sum) {
       this.sum = sum;
+    }
+
+    public C sum() {
+      return this.sum;
     }
 
     /**
@@ -299,7 +303,7 @@ public final class HPre {
      */
     public static <N extends HNat<N>, M extends HNat<M>, R extends HNat<R>, H extends HAdd<N, HSucc<M>, R>>
     HAdd<HSucc<N>, HSucc<M>, HSucc<R>> add(final HSucc<N> a, final HSucc<M> b, final H h) {
-      return new HAdd<HSucc<N>, HSucc<M>, HSucc<R>>(HNat.hSucc(h.sum));
+      return new HAdd<HSucc<N>, HSucc<M>, HSucc<R>>(HNat.hSucc(h.sum()));
     }
   }
 

--- a/project/build/FunctionalJavaProject.scala
+++ b/project/build/FunctionalJavaProject.scala
@@ -7,9 +7,9 @@ abstract class FunctionalJavaDefaults(info: ProjectInfo) extends DefaultProject(
 
   override def compileOptions = target(Target.Java1_5) :: (CompileOptions.Unchecked :: encodingUtf8).map(CompileOption) ++ super.compileOptions
 
-  override def javaCompileOptions = List("-target", "1.5", "-encoding", "UTF-8", "-Xlint:unchecked").map(JavaCompileOption) ++ super.javaCompileOptions
+  override def javaCompileOptions = List("-source", "1.5", "-target", "1.5", "-encoding", "UTF-8", "-Xlint:unchecked").map(JavaCompileOption) ++ super.javaCompileOptions
 
-  def scalacheckDependency = "org.scala-tools.testing" %% "scalacheck" % "1.8" % "test"
+  def scalacheckDependency = "org.scalacheck" %% "scalacheck" % "1.8" % "test"
 
   override def testFrameworks = Seq(new TestFramework("org.scalacheck.ScalaCheckFramework"))
 
@@ -53,10 +53,10 @@ import org.scalacheck.Prop._
   val pubishToRepoName = "Sonatype Nexus Repository Manager"
 
   val publishTo = {
-    val repoUrl = "http://nexus.scala-tools.org/content/repositories/" + (if (version.toString.endsWith("-SNAPSHOT"))
-      "snapshots"
+    val repoUrl = "https://oss.sonatype.org/" + (if (version.toString.endsWith("-SNAPSHOT"))
+      "content/repositories/snapshots"
     else
-      "releases")
+      "service/local/staging/deploy/maven2")
 
     pubishToRepoName at repoUrl
   }


### PR DESCRIPTION
Needed to update the scalacheck dependency after the move off
scala-tools and into maven central - the groupId changes as well.

Corrected some code that was not actually compiling.

I suppose that the build should move to SBT >= 0.11.2?

Signed-off-by: Gary Pamparà gpampara@gmail.com
