### PR TITLE
Improve HashMap with #map, #mapValues, #mapKeys, #foreach

### DIFF
--- a/core/src/main/java/fj/data/HashMap.java
+++ b/core/src/main/java/fj/data/HashMap.java
@@ -229,7 +229,9 @@ public final class HashMap<K, V> implements Iterable<K> {
    * @param v The value to insert.
    */
   public void set(final K k, final V v) {
-    m.put(new Key<K>(k, e, h), v);
+    if (v != null) {
+        m.put(new Key<K>(k, e, h), v);
+    }
   }
 
   /**

--- a/core/src/test/fj/data/CheckHashMap.scala
+++ b/core/src/test/fj/data/CheckHashMap.scala
@@ -103,4 +103,16 @@ object CheckHashMap extends Properties("HashMap") {
       optionEqual(stringEqual).eq(m.get(key), fromMap.get(key)))
     keysAreEqual && valuesAreEqual
   })
+
+  property("No null values") = forAll((m: List[Int]) => {
+    val map = HashMap.hashMap[Int, Int]()
+    m.foreach(new Effect[Int] {
+      def e(a: Int) {
+        map.set(a, null.asInstanceOf[Int])
+      }
+    })
+    m.forall(new F[Int, java.lang.Boolean]() {
+      def f(a: Int) = map.contains(a) == false
+    })
+  })
 }


### PR DESCRIPTION
Improve `HashMap` by implementing the following methods that we have found useful:
-  `#map`
-  `#mapKeys`
-  `#mapValues`
-  `#foreach`

In addition, add conversion to/from `java.util.Map`, and filter out calls to `#set` with a `null` value.
