### PR TITLE
Fixes #4 where TreeMap.split is broken

### DIFF
--- a/core/src/main/java/fj/Equal.java
+++ b/core/src/main/java/fj/Equal.java
@@ -522,6 +522,10 @@ public final class Equal<A> {
     return equal(curry((Set<A> a, Set<A> b) -> streamEqual(e).eq(a.toStream(), b.toStream())));
   }
 
+  public static <K, V> Equal<TreeMap<K, V>> treeMapEqual(Equal<K> k, Equal<V> v) {
+    return equal(t1 -> t2 -> Equal.streamEqual(p2Equal(k, v)).eq(t1.toStream(), t2.toStream()));
+  }
+
   public static <A, B> Equal<Writer<A, B>> writerEqual(Equal<A> eq1, Equal<B> eq2) {
     return equal(w1 -> w2 -> p2Equal(eq1, eq2).eq(w1.run(), w2.run()));
   }

--- a/core/src/main/java/fj/data/Set.java
+++ b/core/src/main/java/fj/data/Set.java
@@ -474,4 +474,18 @@ public abstract class Set<A> implements Iterable<A> {
     return s;
   }
 
+  /**
+   * Constructs a set from the given elements.
+   *
+   * @param o  An order for the elements of the new set.
+   * @param list The elements to add to a set.
+   * @return A new set containing the elements of the given list.
+   */
+  public static <A> Set<A> set(final Ord<A> o, List<A> list) {
+    Set<A> s = empty(o);
+    for (final A a : list)
+      s = s.insert(a);
+    return s;
+  }
+
 }

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -169,6 +169,9 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
     return m;
   }
 
+  public Stream<P2<K, V>> toStream() {
+    return Stream.iteratorStream(iterator());
+  }
   /**
    * An immutable projection of the given mutable map.
    *
@@ -234,11 +237,48 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    *         key in this map, all the elements in the second set are mapped to keys greater than the given key,
    *         and the optional value is the value associated with the given key if present, otherwise None.
    */
-  public P3<Set<V>, Option<V>, Set<V>> split(final K k) {
-    final F<Set<P2<K, Option<V>>>, Set<V>> getSome = F1Functions.mapSet(F1Functions.o(Option.<V>fromSome(), P2.<K, Option<V>>__2())
-        , tree.ord().comap(F1Functions.o(P.<K, Option<V>>p2().f(k), Option.<V>some_())));
+  public P3<Set<V>, Option<V>, Set<V>> split(Ord<V> ord, final K k) {
+    final F<Set<P2<K, Option<V>>>, Set<V>> getSome = F1Functions.mapSet(F1Functions.o(Option.<V>fromSome(), P2.<K, Option<V>>__2()), ord);
     return tree.split(p(k, Option.<V>none())).map1(getSome).map3(getSome)
         .map2(F1Functions.o(Option.<V>join(), F1Functions.mapOption(P2.<K, Option<V>>__2())));
+  }
+
+  /**
+   * Internal construction of a TreeMap from the given set.
+   * @param ord An order for the keys of the tree map.
+   * @param s The elements to construct the tree map with.
+   * @return a TreeMap with the given elements.
+   */
+  private static <K, V> TreeMap<K, V> map(Ord<K> ord, Set<P2<K, Option<V>>> s) {
+    TreeMap<K, V> empty = TreeMap.<K, V>empty(ord);
+    TreeMap<K, V> tree = s.toList().foldLeft((tm, p2) -> {
+      Option<V> opt = p2._2();
+      if (opt.isSome()) {
+        return tm.set(p2._1(), opt.some());
+      }
+      return tm;
+    }, empty);
+    return tree;
+  }
+
+  /**
+   * Splits this TreeMap at the given key. Returns a triple of:
+   * <ul>
+   * <li>A tree map containing all the values of this map associated with keys less than the given key.</li>
+   * <li>An option of a value mapped to the given key, if it exists in this map, otherwise None.
+   * <li>A tree map containing all the values of this map associated with keys greater than the given key.</li>
+   * </ul>
+   *
+   * @param k A key at which to split this map.
+   * @return Two tree maps and an optional value, where all keys in the first tree map are mapped
+   * to keys less than the given key in this map, all the keys in the second tree map are mapped
+   * to keys greater than the given key, and the optional value is the value associated with the
+   * given key if present, otherwise None.
+   */
+  public P3<TreeMap<K, V>, Option<V>, TreeMap<K, V>> splitLookup(final K k) {
+    P3<Set<P2<K, Option<V>>>, Option<P2<K, Option<V>>>, Set<P2<K, Option<V>>>> p3 = tree.split(P.p(k, get(k)));
+    Ord<K> o = tree.ord().<K>comap(k2 -> P.p(k2, Option.<V>none()));
+    return P.p(map(o, p3._1()), get(k), map(o, p3._3()));
   }
 
   /**

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -41,6 +41,32 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
   }
 
   /**
+   * Constructs a tree map from the given elements.
+   *
+   * @param keyOrd An order for the keys of the tree map.
+   * @param p2s The elements to construct the tree map with.
+   * @return a TreeMap with the given elements.
+   */
+  public static <K, V> TreeMap<K, V> map(final Ord<K> keyOrd, final P2<K, V> ... p2s) {
+    return map(keyOrd, List.list(p2s));
+  }
+
+  /**
+   * Constructs a tree map from the given elements.
+   *
+   * @param keyOrd An order for the keys of the tree map.
+   * @param list The elements to construct the tree map with.
+   * @return a TreeMap with the given elements.
+   */
+  public static <K, V> TreeMap<K, V> map(final Ord<K> keyOrd, final List<P2<K, V>> list) {
+    TreeMap<K, V> tm = empty(keyOrd);
+    for (final P2<K, V> p2 : list) {
+      tm = tm.set(p2._1(), p2._2());
+    }
+    return tm;
+  }
+
+  /**
    * Returns a potential value that the given key maps to.
    *
    * @param k The key to look up in the tree map.

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -47,8 +47,8 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    * @param p2s The elements to construct the tree map with.
    * @return a TreeMap with the given elements.
    */
-  public static <K, V> TreeMap<K, V> map(final Ord<K> keyOrd, final P2<K, V> ... p2s) {
-    return map(keyOrd, List.list(p2s));
+  public static <K, V> TreeMap<K, V> treeMap(final Ord<K> keyOrd, final P2<K, V>... p2s) {
+    return treeMap(keyOrd, List.list(p2s));
   }
 
   /**
@@ -58,7 +58,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    * @param list The elements to construct the tree map with.
    * @return a TreeMap with the given elements.
    */
-  public static <K, V> TreeMap<K, V> map(final Ord<K> keyOrd, final List<P2<K, V>> list) {
+  public static <K, V> TreeMap<K, V> treeMap(final Ord<K> keyOrd, final List<P2<K, V>> list) {
     TreeMap<K, V> tm = empty(keyOrd);
     for (final P2<K, V> p2 : list) {
       tm = tm.set(p2._1(), p2._2());
@@ -249,7 +249,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    * @param s The elements to construct the tree map with.
    * @return a TreeMap with the given elements.
    */
-  private static <K, V> TreeMap<K, V> map(Ord<K> ord, Set<P2<K, Option<V>>> s) {
+  private static <K, V> TreeMap<K, V> treeMap(Ord<K> ord, Set<P2<K, Option<V>>> s) {
     TreeMap<K, V> empty = TreeMap.<K, V>empty(ord);
     TreeMap<K, V> tree = s.toList().foldLeft((tm, p2) -> {
       Option<V> opt = p2._2();
@@ -278,7 +278,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
   public P3<TreeMap<K, V>, Option<V>, TreeMap<K, V>> splitLookup(final K k) {
     P3<Set<P2<K, Option<V>>>, Option<P2<K, Option<V>>>, Set<P2<K, Option<V>>>> p3 = tree.split(P.p(k, get(k)));
     Ord<K> o = tree.ord().<K>comap(k2 -> P.p(k2, Option.<V>none()));
-    return P.p(map(o, p3._1()), get(k), map(o, p3._3()));
+    return P.p(treeMap(o, p3._1()), get(k), treeMap(o, p3._3()));
   }
 
   /**

--- a/core/src/test/java/fj/data/TreeMapTest.java
+++ b/core/src/test/java/fj/data/TreeMapTest.java
@@ -5,7 +5,6 @@ import fj.Ord;
 import fj.P3;
 import fj.Show;
 import fj.P;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static fj.data.Option.some;
@@ -22,7 +21,7 @@ public class TreeMapTest {
         int pivot = 4;
         int max = 5;
         List<Integer> l = List.range(1, max + 1);
-        TreeMap<Integer, String> m2 = TreeMap.map(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+        TreeMap<Integer, String> m2 = TreeMap.treeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
         P3<Set<String>, Option<String>, Set<String>> p = m2.split(Ord.stringOrd, pivot);
 
         // print debug info
@@ -53,14 +52,14 @@ public class TreeMapTest {
         int pivot = 4;
         int max = 5;
         List<Integer> l = List.range(1, max + 1);
-        TreeMap<Integer, String> m2 = TreeMap.map(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+        TreeMap<Integer, String> m2 = TreeMap.treeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
         P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>> p3 = m2.splitLookup(pivot);
 
         // create expected output
         List<Integer> leftList = List.range(1, pivot);
-        TreeMap<Integer, String> leftMap = TreeMap.map(Ord.intOrd, leftList.zip(leftList.map(i -> i.toString())));
+        TreeMap<Integer, String> leftMap = TreeMap.treeMap(Ord.intOrd, leftList.zip(leftList.map(i -> i.toString())));
         List<Integer> rightList = List.range(pivot + 1, max + 1);
-        TreeMap<Integer, String> rightMap = TreeMap.map(Ord.intOrd, rightList.zip(rightList.map(i -> i.toString())));
+        TreeMap<Integer, String> rightMap = TreeMap.treeMap(Ord.intOrd, rightList.zip(rightList.map(i -> i.toString())));
 
         // debug info
         if (true) {

--- a/core/src/test/java/fj/data/TreeMapTest.java
+++ b/core/src/test/java/fj/data/TreeMapTest.java
@@ -4,8 +4,12 @@ import fj.Equal;
 import fj.Ord;
 import fj.P3;
 import fj.Show;
+import fj.P;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static fj.data.Option.some;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by MarkPerry on 11/01/2015.
@@ -14,28 +18,61 @@ public class TreeMapTest {
 
     @Test
     public void split() {
+        // do the split
         int pivot = 4;
-        List<Integer> l = List.range(1, 6);
+        int max = 5;
+        List<Integer> l = List.range(1, max + 1);
         TreeMap<Integer, String> m2 = TreeMap.map(Ord.intOrd, l.zip(l.map(i -> i.toString())));
-        P3<Set<String>, Option<String>, Set<String>> p = m2.split(pivot);
+        P3<Set<String>, Option<String>, Set<String>> p = m2.split(Ord.stringOrd, pivot);
+
+        // print debug info
         Show<TreeMap<Integer, String>> st = Show.treeMapShow(Show.intShow, Show.stringShow);
         Show<Set<String>> ss = Show.setShow(Show.stringShow);
         Show<Option<String>> so = Show.optionShow(Show.stringShow);
         Show<P3<Set<String>, Option<String>, Set<String>>> sp3 = Show.p3Show(ss, so, ss);
+        if (true) {
+            st.println(m2);
+            sp3.println(p);
+        }
 
-        st.println(m2);
-        sp3.println(p);
-
-        Equal<Set<String>> eq = Equal.setEqual(Equal.stringEqual);
-        Set<String> left = toSetString(List.list(1, 2, 3));
-        Set<String> right = toSetString(List.list(5));
-        Assert.assertTrue("Left side of split unexpected", eq.eq(left, p._1()));
-        Assert.assertTrue(eq.eq(right, p._1()));
-        Assert.assertTrue(Equal.optionEqual(Equal.stringEqual).eq(p._2(), Option.some(Integer.toString(pivot))));
+        // assert equals
+        Equal<Set<String>> seq = Equal.setEqual(Equal.stringEqual);
+        Set<String> left = toSetString(List.range(1, pivot));
+        Set<String> right = toSetString(List.range(pivot + 1, max + 1));
+        P3<Set<String>, Option<String>, Set<String>> expected = P.p(left, some(Integer.toString(pivot)), right);
+        assertTrue(Equal.p3Equal(seq, Equal.optionEqual(Equal.stringEqual), seq).eq(p, expected));
     }
 
     private static Set<String> toSetString(List<Integer> list) {
         return Set.set(Ord.stringOrd, list.map(i -> i.toString()));
+    }
+
+    @Test
+    public void splitLookup() {
+        // do the split
+        int pivot = 4;
+        int max = 5;
+        List<Integer> l = List.range(1, max + 1);
+        TreeMap<Integer, String> m2 = TreeMap.map(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+        P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>> p3 = m2.splitLookup(pivot);
+
+        // create expected output
+        List<Integer> leftList = List.range(1, pivot);
+        TreeMap<Integer, String> leftMap = TreeMap.map(Ord.intOrd, leftList.zip(leftList.map(i -> i.toString())));
+        List<Integer> rightList = List.range(pivot + 1, max + 1);
+        TreeMap<Integer, String> rightMap = TreeMap.map(Ord.intOrd, rightList.zip(rightList.map(i -> i.toString())));
+
+        // debug info
+        if (true) {
+            Show<TreeMap<Integer, String>> st = Show.treeMapShow(Show.intShow, Show.stringShow);
+            Show<P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>>> sp3 = Show.p3Show(st, Show.optionShow(Show.stringShow), st);
+            sp3.println(p3);
+        }
+
+        // do the assert
+        Equal<TreeMap<Integer, String>> tme = Equal.treeMapEqual(Equal.intEqual, Equal.stringEqual);
+        Equal<P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>>> eq = Equal.p3Equal(tme, Equal.optionEqual(Equal.stringEqual), tme);
+        assertTrue(eq.eq(p3, P.p(leftMap, some(Integer.toString(pivot)), rightMap)));
     }
 
 }

--- a/core/src/test/java/fj/data/TreeMapTest.java
+++ b/core/src/test/java/fj/data/TreeMapTest.java
@@ -1,0 +1,41 @@
+package fj.data;
+
+import fj.Equal;
+import fj.Ord;
+import fj.P3;
+import fj.Show;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by MarkPerry on 11/01/2015.
+ */
+public class TreeMapTest {
+
+    @Test
+    public void split() {
+        int pivot = 4;
+        List<Integer> l = List.range(1, 6);
+        TreeMap<Integer, String> m2 = TreeMap.map(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+        P3<Set<String>, Option<String>, Set<String>> p = m2.split(pivot);
+        Show<TreeMap<Integer, String>> st = Show.treeMapShow(Show.intShow, Show.stringShow);
+        Show<Set<String>> ss = Show.setShow(Show.stringShow);
+        Show<Option<String>> so = Show.optionShow(Show.stringShow);
+        Show<P3<Set<String>, Option<String>, Set<String>>> sp3 = Show.p3Show(ss, so, ss);
+
+        st.println(m2);
+        sp3.println(p);
+
+        Equal<Set<String>> eq = Equal.setEqual(Equal.stringEqual);
+        Set<String> left = toSetString(List.list(1, 2, 3));
+        Set<String> right = toSetString(List.list(5));
+        Assert.assertTrue("Left side of split unexpected", eq.eq(left, p._1()));
+        Assert.assertTrue(eq.eq(right, p._1()));
+        Assert.assertTrue(Equal.optionEqual(Equal.stringEqual).eq(p._2(), Option.some(Integer.toString(pivot))));
+    }
+
+    private static Set<String> toSetString(List<Integer> list) {
+        return Set.set(Ord.stringOrd, list.map(i -> i.toString()));
+    }
+
+}


### PR DESCRIPTION
To support this change this PR also adds:
- Equal.treeMapEqual
- Set.set
- TreeMap.treeMap, toStream and splitLookup