### PR TITLE
fix LazyString#toString for android

### DIFF
--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -108,7 +108,7 @@ public final class LazyString implements CharSequence {
    * @return The String representation of this lazy string.
    */
   public String toString() {
-    return new StringBuilder(this).toString();
+    return new StringBuilder(length() + 16).append(this).toString();
   }
 
   /**


### PR DESCRIPTION
java.lang.StackOverflowError occurred on Android

e.x.

`Option.fromNull("hoge").toString()`

```
02-17 00:46:30.111    3923-3923/com.example.myapplication E/AndroidRuntime﹕ FATAL EXCEPTION: main
    Process: com.example.myapplication, PID: 3923
    java.lang.StackOverflowError: stack size 8MB
            at fj.data.LazyString.toString(LazyString.java:111)
            at java.lang.StringBuilder.<init>(StringBuilder.java:81)
            at fj.data.LazyString.toString(LazyString.java:111)
            at java.lang.StringBuilder.<init>(StringBuilder.java:81)
            at fj.data.LazyString.toString(LazyString.java:111)
...
```

reason

Android's StringBuilder is different from Java (older than java?)
* [Android's StringBuilder](https://android.googlesource.com/platform/libcore/+/android-5.0.2_r1/luni/src/main/java/java/lang/StringBuffer.java#97)
* [Java StringBuilder](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/lang/StringBuilder.java#124)
