### PR TITLE
avoid overflow

### DIFF
--- a/core/src/main/java/fj/test/Rand.java
+++ b/core/src/main/java/fj/test/Rand.java
@@ -130,9 +130,14 @@ public final class Rand {
         public F<Integer, Integer> f(final Integer from) {
           return new F<Integer, Integer>() {
             public Integer f(final Integer to) {
-              final int f = min(from, to);
-              final int t = max(from, to);
-              return f + seed.map(fr).orSome(new Random()).nextInt(t - f + 1);
+              if(from == to){
+                return from;
+              }else{
+                final int f = min(from, to);
+                final int t = max(from, to);
+                final int x = Math.abs(t - f);
+                return f + seed.map(fr).orSome(new Random()).nextInt(x == Integer.MIN_VALUE ? Integer.MAX_VALUE : x);
+              }
             }
           };
         }


### PR DESCRIPTION
```
scala version 2.11.5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_25).
Type in expressions to have them evaluated.
Type :help for more information.

scala> fj.test.Rand.standard.choose(Int.MinValue, Int.MaxValue)
java.lang.IllegalArgumentException: bound must be positive
  at java.util.Random.nextInt(Random.java:388)
  at fj.test.Rand$4$1$1.f(Rand.java:135)
  at fj.test.Rand$4$1$1.f(Rand.java:131)
  at fj.test.Rand.choose(Rand.java:45)
```