### PR TITLE
Fixed #133 and #135

### DIFF
--- a/core/src/main/java/fj/Effect.java
+++ b/core/src/main/java/fj/Effect.java
@@ -22,7 +22,10 @@ public class Effect {
 	private Effect() {}
 
     public static P1<Unit> f(Effect0 e) {
-        return P.lazy(u -> unit());
+      return P.lazy(() -> {
+        e.f();
+        return unit();
+      });
     }
 
     /**

--- a/core/src/main/java/fj/Effect.java
+++ b/core/src/main/java/fj/Effect.java
@@ -95,7 +95,7 @@ public class Effect {
    * @param f The function to map over the effect.
    * @return An effect after a contra-variant map.
    */
-  public final <A, B> Effect1<B> comap(Effect1<A> e1, final F<B, A> f) {
+  public static final <A, B> Effect1<B> comap(Effect1<A> e1, final F<B, A> f) {
     return b -> e1.f(f.f(b));
   }
   


### PR DESCRIPTION
Effect.f(Effect0) now does not ignore its argument.
Effect.comap is now static.