### PR TITLE
Replace P1 by F0 in method arguments of various API

### DIFF
--- a/core/src/main/java/fj/Effect.java
+++ b/core/src/main/java/fj/Effect.java
@@ -22,7 +22,7 @@ public class Effect {
 	private Effect() {}
 
     public static P1<Unit> f(Effect0 e) {
-        return P.lazy(u -> unit());
+        return P.lazy(() -> unit());
     }
 
     /**

--- a/core/src/main/java/fj/F1Functions.java
+++ b/core/src/main/java/fj/F1Functions.java
@@ -128,7 +128,7 @@ public class F1Functions {
      * @return This function promoted to return its result in a product-1.
      */
     static public <A, B> F<A, P1<B>> lazy(final F<A, B> f) {
-       return a -> P.lazy(u -> f.f(a));
+       return a -> P.lazy(() -> f.f(a));
     }
 
     /**
@@ -138,7 +138,7 @@ public class F1Functions {
      * @return The function partially applied to the given argument to return a lazy value.
      */
     static public <A, B> P1<B> f(final F<A, B> f, final A a) {
-        return P.lazy(u -> f.f(a));
+        return P.lazy(() -> f.f(a));
     }
 
     /**

--- a/core/src/main/java/fj/P.java
+++ b/core/src/main/java/fj/P.java
@@ -44,192 +44,192 @@ public final class P {
         return pa;
     }
 
-    public static <A, B> P2<A, B> lazy(final P1<A> pa, final P1<B> pb) {
+    public static <A, B> P2<A, B> lazy(final F0<A> pa, final F0<B> pb) {
         return new P2<A, B>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
         };
     }
 
-    public static <A, B, C> P3<A, B, C> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc) {
+    public static <A, B, C> P3<A, B, C> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc) {
         return new P3<A, B, C>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
         };
     }
 
-    public static <A, B, C, D> P4<A, B, C, D> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc, final P1<D> pd) {
+    public static <A, B, C, D> P4<A, B, C, D> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc, final F0<D> pd) {
         return new P4<A, B, C, D>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
 
             @Override
             public D _4() {
-                return pd._1();
+                return pd.f();
             }
         };
     }
 
-    public static <A, B, C, D, E> P5<A, B, C, D, E> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc, final P1<D> pd, P1<E> pe) {
+    public static <A, B, C, D, E> P5<A, B, C, D, E> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc, final F0<D> pd, F0<E> pe) {
         return new P5<A, B, C, D, E>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
 
             @Override
             public D _4() {
-                return pd._1();
+                return pd.f();
             }
 
             @Override
             public E _5() {
-                return pe._1();
+                return pe.f();
             }
         };
     }
 
-    public static <A, B, C, D, E, F> P6<A, B, C, D, E, F> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc, final P1<D> pd, P1<E> pe, P1<F> pf) {
+    public static <A, B, C, D, E, F> P6<A, B, C, D, E, F> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc, final F0<D> pd, F0<E> pe, F0<F> pf) {
         return new P6<A, B, C, D, E, F>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
 
             @Override
             public D _4() {
-                return pd._1();
+                return pd.f();
             }
 
             @Override
             public E _5() {
-                return pe._1();
+                return pe.f();
             }
 
             @Override
             public F _6() {
-                return pf._1();
+                return pf.f();
             }
         };
     }
 
-    public static <A, B, C, D, E, F, G> P7<A, B, C, D, E, F, G> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc, final P1<D> pd, P1<E> pe, P1<F> pf, P1<G> pg) {
+    public static <A, B, C, D, E, F, G> P7<A, B, C, D, E, F, G> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc, final F0<D> pd, F0<E> pe, F0<F> pf, F0<G> pg) {
         return new P7<A, B, C, D, E, F, G>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
 
             @Override
             public D _4() {
-                return pd._1();
+                return pd.f();
             }
 
             @Override
             public E _5() {
-                return pe._1();
+                return pe.f();
             }
 
             @Override
             public F _6() {
-                return pf._1();
+                return pf.f();
             }
 
             @Override
             public G _7() {
-                return pg._1();
+                return pg.f();
             }
         };
     }
 
-    public static <A, B, C, D, E, F, G, H> P8<A, B, C, D, E, F, G, H> lazy(final P1<A> pa, final P1<B> pb, final P1<C> pc, final P1<D> pd, P1<E> pe, P1<F> pf, P1<G> pg, P1<H> ph) {
+    public static <A, B, C, D, E, F, G, H> P8<A, B, C, D, E, F, G, H> lazy(final F0<A> pa, final F0<B> pb, final F0<C> pc, final F0<D> pd, F0<E> pe, F0<F> pf, F0<G> pg, F0<H> ph) {
         return new P8<A, B, C, D, E, F, G, H>() {
             @Override
             public A _1() {
-                return pa._1();
+                return pa.f();
             }
             @Override
             public B _2() {
-                return pb._1();
+                return pb.f();
             }
             @Override
             public C _3() {
-                return pc._1();
+                return pc.f();
             }
 
             @Override
             public D _4() {
-                return pd._1();
+                return pd.f();
             }
 
             @Override
             public E _5() {
-                return pe._1();
+                return pe.f();
             }
 
             @Override
             public F _6() {
-                return pf._1();
+                return pf.f();
             }
 
             @Override
             public G _7() {
-                return pg._1();
+                return pg.f();
             }
 
             @Override
             public H _8() {
-                return ph._1();
+                return ph.f();
             }
         };
     }
@@ -240,15 +240,7 @@ public final class P {
    * @return A function that puts an element in a product-2.
    */
   public static <A, B> F<A, F<B, P2<A, B>>> p2() {
-    return new F<A, F<B, P2<A, B>>>() {
-      public F<B, P2<A, B>> f(final A a) {
-        return new F<B, P2<A, B>>() {
-          public P2<A, B> f(final B b) {
-            return p(a, b);
-          }
-        };
-      }
-    };
+    return a -> b -> p(a, b);
   }
 
   /**
@@ -271,24 +263,12 @@ public final class P {
   }
 
   /**
-   * A function that puts an element in a product-3.
+   * A function that puts elements in a product-3.
    *
-   * @return A function that puts an element in a product-3.
+   * @return A function that puts elements in a product-3.
    */
   public static <A, B, C> F<A, F<B, F<C, P3<A, B, C>>>> p3() {
-    return new F<A, F<B, F<C, P3<A, B, C>>>>() {
-      public F<B, F<C, P3<A, B, C>>> f(final A a) {
-        return new F<B, F<C, P3<A, B, C>>>() {
-          public F<C, P3<A, B, C>> f(final B b) {
-            return new F<C, P3<A, B, C>>() {
-              public P3<A, B, C> f(final C c) {
-                return p(a, b, c);
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> p(a, b, c);
   }
 
   /**
@@ -321,23 +301,7 @@ public final class P {
    * @return A function that puts an element in a product-4.
    */
   public static <A, B, C, D> F<A, F<B, F<C, F<D, P4<A, B, C, D>>>>> p4() {
-    return new F<A, F<B, F<C, F<D, P4<A, B, C, D>>>>>() {
-      public F<B, F<C, F<D, P4<A, B, C, D>>>> f(final A a) {
-        return new F<B, F<C, F<D, P4<A, B, C, D>>>>() {
-          public F<C, F<D, P4<A, B, C, D>>> f(final B b) {
-            return new F<C, F<D, P4<A, B, C, D>>>() {
-              public F<D, P4<A, B, C, D>> f(final C c) {
-                return new F<D, P4<A, B, C, D>>() {
-                  public P4<A, B, C, D> f(final D d) {
-                    return p(a, b, c, d);
-                  }
-                };
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> d -> p(a, b, c, d);
   }
 
   /**
@@ -375,27 +339,7 @@ public final class P {
    * @return A function that puts an element in a product-5.
    */
   public static <A, B, C, D, E> F<A, F<B, F<C, F<D, F<E, P5<A, B, C, D, E>>>>>> p5() {
-    return new F<A, F<B, F<C, F<D, F<E, P5<A, B, C, D, E>>>>>>() {
-      public F<B, F<C, F<D, F<E, P5<A, B, C, D, E>>>>> f(final A a) {
-        return new F<B, F<C, F<D, F<E, P5<A, B, C, D, E>>>>>() {
-          public F<C, F<D, F<E, P5<A, B, C, D, E>>>> f(final B b) {
-            return new F<C, F<D, F<E, P5<A, B, C, D, E>>>>() {
-              public F<D, F<E, P5<A, B, C, D, E>>> f(final C c) {
-                return new F<D, F<E, P5<A, B, C, D, E>>>() {
-                  public F<E, P5<A, B, C, D, E>> f(final D d) {
-                    return new F<E, P5<A, B, C, D, E>>() {
-                      public P5<A, B, C, D, E> f(final E e) {
-                        return p(a, b, c, d, e);
-                      }
-                    };
-                  }
-                };
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> d -> e -> p(a, b, c, d, e);
   }
 
   /**
@@ -438,31 +382,7 @@ public final class P {
    * @return A function that puts an element in a product-6.
    */
   public static <A, B, C, D, E, F$> F<A, F<B, F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>>>> p6() {
-    return new F<A, F<B, F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>>>>() {
-      public F<B, F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>>> f(final A a) {
-        return new F<B, F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>>>() {
-          public F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>> f(final B b) {
-            return new F<C, F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>>() {
-              public F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>> f(final C c) {
-                return new F<D, F<E, F<F$, P6<A, B, C, D, E, F$>>>>() {
-                  public F<E, F<F$, P6<A, B, C, D, E, F$>>> f(final D d) {
-                    return new F<E, F<F$, P6<A, B, C, D, E, F$>>>() {
-                      public F<F$, P6<A, B, C, D, E, F$>> f(final E e) {
-                        return new F<F$, P6<A, B, C, D, E, F$>>() {
-                          public P6<A, B, C, D, E, F$> f(final F$ f) {
-                            return p(a, b, c, d, e, f);
-                          }
-                        };
-                      }
-                    };
-                  }
-                };
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> d -> e -> f -> p(a, b, c, d, e, f);
   }
 
   /**
@@ -510,35 +430,7 @@ public final class P {
    * @return A function that puts an element in a product-7.
    */
   public static <A, B, C, D, E, F$, G> F<A, F<B, F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>>>> p7() {
-    return new F<A, F<B, F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>>>>() {
-      public F<B, F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>>> f(final A a) {
-        return new F<B, F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>>>() {
-          public F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>> f(final B b) {
-            return new F<C, F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>>() {
-              public F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>> f(final C c) {
-                return new F<D, F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>>() {
-                  public F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>> f(final D d) {
-                    return new F<E, F<F$, F<G, P7<A, B, C, D, E, F$, G>>>>() {
-                      public F<F$, F<G, P7<A, B, C, D, E, F$, G>>> f(final E e) {
-                        return new F<F$, F<G, P7<A, B, C, D, E, F$, G>>>() {
-                          public F<G, P7<A, B, C, D, E, F$, G>> f(final F$ f) {
-                            return new F<G, P7<A, B, C, D, E, F$, G>>() {
-                              public P7<A, B, C, D, E, F$, G> f(final G g) {
-                                return p(a, b, c, d, e, f, g);
-                              }
-                            };
-                          }
-                        };
-                      }
-                    };
-                  }
-                };
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> d -> e -> f -> g -> p(a, b, c, d, e, f, g);
   }
   
   /**
@@ -591,39 +483,7 @@ public final class P {
    * @return A function that puts an element in a product-8.
    */
   public static <A, B, C, D, E, F$, G, H> F<A, F<B, F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>>>> p8() {
-    return new F<A, F<B, F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>>>>() {
-      public F<B, F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>>> f(final A a) {
-        return new F<B, F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>>>() {
-          public F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>> f(final B b) {
-            return new F<C, F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>>() {
-              public F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>> f(final C c) {
-                return new F<D, F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>>() {
-                  public F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>> f(final D d) {
-                    return new F<E, F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>>() {
-                      public F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>> f(final E e) {
-                        return new F<F$, F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>>() {
-                          public F<G, F<H, P8<A, B, C, D, E, F$, G, H>>> f(final F$ f) {
-                            return new F<G, F<H, P8<A, B, C, D, E, F$, G, H>>>() {
-                              public F<H, P8<A, B, C, D, E, F$, G, H>> f(final G g) {
-                                return new F<H, P8<A, B, C, D, E, F$, G, H>>() {
-                                  public P8<A, B, C, D, E, F$, G, H> f(final H h) {
-                                    return p(a, b, c, d, e, f, g, h);
-                                  }
-                                };
-                              }
-                            };
-                          }
-                        };
-                      }
-                    };
-                  }
-                };
-              }
-            };
-          }
-        };
-      }
-    };
+    return a -> b -> c -> d -> e -> f -> g -> h -> p(a, b, c, d, e, f, g, h);
   }
 
   /**

--- a/core/src/main/java/fj/P1.java
+++ b/core/src/main/java/fj/P1.java
@@ -14,7 +14,7 @@ import fj.function.Try0;
 public abstract class P1<A> implements F0<A> {
 
     @Override
-    public A f() {
+    public final A f() {
         return _1();
     }
 
@@ -52,7 +52,7 @@ public abstract class P1<A> implements F0<A> {
      */
     public <B> P1<B> bind(final F<A, P1<B>> f) {
         P1<A> self = this;
-        return P.lazy(u -> f.f(self._1())._1());
+        return P.lazy(() -> f.f(self._1())._1());
     }
 
     /**
@@ -62,7 +62,7 @@ public abstract class P1<A> implements F0<A> {
      * @return A function whose result is wrapped in a P1.
      */
     public static <A, B> F<A, P1<B>> curry(final F<A, B> f) {
-        return a -> P.lazy(u -> f.f(a));
+        return a -> P.lazy(() -> f.f(a));
     }
 
     /**
@@ -143,7 +143,7 @@ public abstract class P1<A> implements F0<A> {
      * @return A single P1 for the given array.
      */
     public static <A> P1<Array<A>> sequence(final Array<P1<A>> as) {
-        return P.lazy(u -> as.map(P1.<A>__1()));
+        return P.lazy(() -> as.map(P1.<A>__1()));
     }
 
     /**
@@ -204,7 +204,7 @@ public abstract class P1<A> implements F0<A> {
        */
       public <X> P1<X> map(final F<A, X> f) {
           final P1<A> self = this;
-        return P.lazy(u -> f.f(self._1()));
+        return P.lazy(() -> f.f(self._1()));
       }
 
     /**
@@ -257,7 +257,7 @@ public abstract class P1<A> implements F0<A> {
     @SuppressWarnings("unchecked")
     @Override
     public boolean equals(Object other) {
-        return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p1Equal(Equal.<A>anyEqual()).eq(this, (P1<A>) other)));
+        return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p1Equal(Equal.<A>anyEqual()).eq(this, (P1<A>) other));
     }
 
     @Override

--- a/core/src/main/java/fj/P2.java
+++ b/core/src/main/java/fj/P2.java
@@ -26,7 +26,7 @@ public abstract class P2<A, B> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p2Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual()).eq(this, (P2<A, B>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p2Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual()).eq(this, (P2<A, B>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P3.java
+++ b/core/src/main/java/fj/P3.java
@@ -192,7 +192,7 @@ public abstract class P3<A, B, C> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p3Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual()).eq(this, (P3<A, B, C>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p3Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual()).eq(this, (P3<A, B, C>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P4.java
+++ b/core/src/main/java/fj/P4.java
@@ -265,7 +265,7 @@ public abstract class P4<A, B, C, D> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p4Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual()).eq(this, (P4<A, B, C, D>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p4Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual()).eq(this, (P4<A, B, C, D>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P5.java
+++ b/core/src/main/java/fj/P5.java
@@ -344,7 +344,7 @@ public abstract class P5<A, B, C, D, E> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p5Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual()).eq(this, (P5<A, B, C, D, E>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p5Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual()).eq(this, (P5<A, B, C, D, E>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P6.java
+++ b/core/src/main/java/fj/P6.java
@@ -435,7 +435,7 @@ public abstract class P6<A, B, C, D, E, F> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p6Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual()).eq(this, (P6<A, B, C, D, E, F>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p6Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual()).eq(this, (P6<A, B, C, D, E, F>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P7.java
+++ b/core/src/main/java/fj/P7.java
@@ -529,7 +529,7 @@ public abstract class P7<A, B, C, D, E, F, G> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p7Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual(), Equal.<G>anyEqual()).eq(this, (P7<A, B, C, D, E, F, G>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p7Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual(), Equal.<G>anyEqual()).eq(this, (P7<A, B, C, D, E, F, G>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/P8.java
+++ b/core/src/main/java/fj/P8.java
@@ -635,7 +635,7 @@ public abstract class P8<A, B, C, D, E, F, G, H> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.p8Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual(), Equal.<G>anyEqual(), Equal.<H>anyEqual()).eq(this, (P8<A, B, C, D, E, F, G, H>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.p8Equal(Equal.<A>anyEqual(), Equal.<B>anyEqual(), Equal.<C>anyEqual(), Equal.<D>anyEqual(), Equal.<E>anyEqual(), Equal.<F>anyEqual(), Equal.<G>anyEqual(), Equal.<H>anyEqual()).eq(this, (P8<A, B, C, D, E, F, G, H>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/Try.java
+++ b/core/src/main/java/fj/Try.java
@@ -22,7 +22,7 @@ public class Try {
      * @return A Validation with an Exception on the failure side and its result on the success side.
      */
     static public <A, E extends Exception> P1<Validation<E, A>> f(final Try0<A, E> t) {
-        return P.lazy(u -> {
+        return P.lazy(() -> {
             try {
                 return success(t.f());
             } catch (Exception e) {

--- a/core/src/main/java/fj/TryEffect.java
+++ b/core/src/main/java/fj/TryEffect.java
@@ -15,7 +15,7 @@ public class TryEffect {
     private TryEffect(){}
 
     public static <A, Z extends Exception> P1<Validation<Z, Unit>> f(TryEffect0<Z> t) {
-        return P.lazy(u -> {
+        return P.lazy(() -> {
             try {
                 t.f();
                 return Validation.success(Unit.unit());

--- a/core/src/main/java/fj/control/Trampoline.java
+++ b/core/src/main/java/fj/control/Trampoline.java
@@ -46,7 +46,7 @@ public abstract class Trampoline<A> {
     // The monadic bind constructs a new Codense whose subcomputation is still `sub`, and Kleisli-composes the
     // continuations.
     public <B> Trampoline<B> bind(final F<A, Trampoline<B>> f) {
-      return codense(sub, o -> suspend(P.lazy(u -> cont.f(o).bind(f))));
+      return codense(sub, o -> suspend(P.lazy(() -> cont.f(o).bind(f))));
     }
 
     // The resumption of a Codense is the resumption of its subcomputation. If that computation is done, its result
@@ -61,7 +61,7 @@ public abstract class Trampoline<A> {
           F<Codense<Object>, Trampoline<A>> g = c -> codense(c.sub, o -> c.cont.f(o).bind(cont));
           return ot.fold(f, g);
         });
-      }, o -> P.lazy(u -> cont.f(o))));
+      }, o -> P.lazy(() -> cont.f(o))));
     }
   }
 
@@ -259,7 +259,7 @@ public abstract class Trampoline<A> {
     final Either<P1<Trampoline<B>>, B> eb = b.resume();
     for (final P1<Trampoline<A>> x : ea.left()) {
       for (final P1<Trampoline<B>> y : eb.left()) {
-        return suspend(x.bind(y, F2Functions.curry((ta, tb) -> suspend(P.<Trampoline<C>>lazy(u -> ta.zipWith(tb, f))))));
+        return suspend(x.bind(y, F2Functions.curry((ta, tb) -> suspend(P.<Trampoline<C>>lazy(() -> ta.zipWith(tb, f))))));
       }
       for (final B y : eb.right()) {
         return suspend(x.map(ta -> ta.map(F2Functions.f(F2Functions.flip(f), y))));
@@ -267,7 +267,7 @@ public abstract class Trampoline<A> {
     }
     for (final A x : ea.right()) {
       for (final B y : eb.right()) {
-        return suspend(P.lazy(u -> pure(f.f(x, y))));
+        return suspend(P.lazy(() -> pure(f.f(x, y))));
       }
       for (final P1<Trampoline<B>> y : eb.left()) {
         return suspend(y.map(liftM2(F2Functions.curry(f)).f(pure(x))));

--- a/core/src/main/java/fj/control/parallel/Callables.java
+++ b/core/src/main/java/fj/control/parallel/Callables.java
@@ -1,6 +1,7 @@
 package fj.control.parallel;
 
 import fj.F;
+import fj.F0;
 import fj.F2;
 import fj.Function;
 import static fj.Function.curry;
@@ -221,10 +222,10 @@ public final class Callables {
    * @param e Either an exception or a value to wrap in a Callable
    * @return A Callable equivalent to the given Either value.
    */
-  public static <A> Callable<A> fromEither(final P1<Either<Exception, A>> e) {
+  public static <A> Callable<A> fromEither(final F0<Either<Exception, A>> e) {
     return new Callable<A>() {
       public A call() throws Exception {
-        final Either<Exception, A> e1 = e._1();
+        final Either<Exception, A> e1 = e.f();
         if (e1.isLeft())
           throw e1.left().value();
         else
@@ -248,10 +249,10 @@ public final class Callables {
    * @param o An optional value to turn into a Callable.
    * @return A Callable that yields some value or throws an exception in the case of no value.
    */
-  public static <A> Callable<A> fromOption(final P1<Option<A>> o) {
+  public static <A> Callable<A> fromOption(final F0<Option<A>> o) {
     return new Callable<A>() {
       public A call() throws Exception {
-        final Option<A> o1 = o._1();
+        final Option<A> o1 = o.f();
         if (o1.isSome())
           return o1.some();
         else

--- a/core/src/main/java/fj/control/parallel/Promise.java
+++ b/core/src/main/java/fj/control/parallel/Promise.java
@@ -348,7 +348,7 @@ public final class Promise<A> {
     return new F<Stream<A>, Promise<B>>() {
       public Promise<B> f(final Stream<A> as) {
         return as.isEmpty() ? promise(s, P.p(b)) : liftM2(f).f(promise(s, P.p(as.head()))).f(
-                Promise.<P1<B>>join(s, P.lazy(u -> f(as.tail()._1()).fmap(P.<B>p1()))));
+                Promise.<P1<B>>join(s, P.lazy(() -> f(as.tail()._1()).fmap(P.<B>p1()))));
       }
     };
   }

--- a/core/src/main/java/fj/control/parallel/Strategy.java
+++ b/core/src/main/java/fj/control/parallel/Strategy.java
@@ -322,7 +322,7 @@ public final class Strategy<A> {
    * @return A product-1 that waits for the given future to obtain a value.
    */
   public static <A> P1<A> obtain(final Future<A> t) {
-    return P.lazy(u -> {
+    return P.lazy(() -> {
         try {
           return t.get();
         } catch (InterruptedException e) {
@@ -453,7 +453,7 @@ public final class Strategy<A> {
    * @return A strategy that captures any runtime errors with a side-effect.
    */
   public static <A> Strategy<A> errorStrategy(final Strategy<A> s, final Effect1<Error> e) {
-    return s.comap(a -> P.lazy(u -> {
+    return s.comap(a -> P.lazy(() -> {
         try {
           return a._1();
         } catch (Throwable t) {

--- a/core/src/main/java/fj/data/Array.java
+++ b/core/src/main/java/fj/data/Array.java
@@ -1,6 +1,7 @@
 package fj.data;
 
 import fj.F;
+import fj.F0;
 import fj.F2;
 import fj.P;
 import fj.P1;
@@ -10,7 +11,6 @@ import fj.Show;
 import fj.Hash;
 import fj.Unit;
 import fj.function.Effect1;
-
 import static fj.Function.*;
 import static fj.P.p;
 import static fj.P.p2;
@@ -18,7 +18,6 @@ import static fj.Unit.unit;
 import static fj.data.List.iterableList;
 import static fj.data.Option.none;
 import static fj.data.Option.some;
-
 import static java.lang.Math.min;
 import static java.lang.System.arraycopy;
 
@@ -145,8 +144,8 @@ public final class Array<A> implements Iterable<A> {
    * @return An either projection of this array.
    */
   @SuppressWarnings("unchecked")
-  public <X> Either<X, A> toEither(final P1<X> x) {
-    return a.length == 0 ? Either.<X, A>left(x._1()) : Either.<X, A>right((A) a[0]);
+  public <X> Either<X, A> toEither(final F0<X> x) {
+    return a.length == 0 ? Either.<X, A> left(x.f()) : Either.<X, A> right((A) a[0]);
   }
 
   /**
@@ -682,7 +681,7 @@ public final class Array<A> implements Iterable<A> {
 
   @Override
   public boolean equals(Object o) {
-    return Equal.shallowEqualsO(this, o).orSome(P.lazy(u -> Equal.arrayEqual(Equal.<A>anyEqual()).eq(this, (Array<A>) o)));
+    return Equal.shallowEqualsO(this, o).orSome(() -> Equal.arrayEqual(Equal.<A>anyEqual()).eq(this, (Array<A>) o));
   }
 
   /**
@@ -926,7 +925,7 @@ public final class Array<A> implements Iterable<A> {
      * @param x The value to return in left if this array is empty.
      * @return An either projection of this array.
      */
-    public <X> Either<X, A> toEither(final P1<X> x) {
+    public <X> Either<X, A> toEither(final F0<X> x) {
       return a.toEither(x);
     }
 

--- a/core/src/main/java/fj/data/Either.java
+++ b/core/src/main/java/fj/data/Either.java
@@ -94,7 +94,7 @@ public abstract class Either<A, B> {
   @Override
   public boolean equals(Object other) {
 
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.eitherEqual(Equal.<A>anyEqual(), Equal.<B>anyEqual()).eq(this, (Either<A, B>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.eitherEqual(Equal.<A>anyEqual(), Equal.<B>anyEqual()).eq(this, (Either<A, B>) other));
   }
 
   @Override
@@ -177,12 +177,12 @@ public abstract class Either<A, B> {
      * @param err The error message to fail with.
      * @return The value of this projection
      */
-    public A valueE(final P1<String> err) {
+    public A valueE(final F0<String> err) {
       if (e.isLeft())
         //noinspection CastToConcreteClass
         return ((Left<A, B>) e).a;
       else
-        throw error(err._1());
+        throw error(err.f());
     }
 
     /**
@@ -210,8 +210,8 @@ public abstract class Either<A, B> {
      * @param a The value to return if this projection has no value.
      * @return The value of this projection or the given argument.
      */
-    public A orValue(final P1<A> a) {
-      return isLeft() ? value() : a._1();
+    public A orValue(final F0<A> a) {
+      return isLeft() ? value() : a.f();
     }
 
     /**
@@ -462,12 +462,12 @@ public abstract class Either<A, B> {
      * @param err The error message to fail with.
      * @return The value of this projection
      */
-    public B valueE(final P1<String> err) {
+    public B valueE(final F0<String> err) {
       if (e.isRight())
         //noinspection CastToConcreteClass
         return ((Right<A, B>) e).b;
       else
-        throw error(err._1());
+        throw error(err.f());
     }
 
     /**
@@ -485,8 +485,8 @@ public abstract class Either<A, B> {
      * @param b The value to return if this projection has no value.
      * @return The value of this projection or the given argument.
      */
-    public B orValue(final P1<B> b) {
-      return isRight() ? value() : b._1();
+    public B orValue(final F0<B> b) {
+      return isRight() ? value() : b.f();
     }
 
     /**
@@ -575,7 +575,7 @@ public abstract class Either<A, B> {
       public <C> IO<Either<A, C>> traverseIO(final F<B, IO<C>> f) {
           return isRight() ?
                   IOFunctions.map(f.f(value()), x -> Either.<A, C>right(x)) :
-                  IOFunctions.lazy(u -> Either.<A, C>left(e.left().value()));
+                  IOFunctions.lazy(() -> Either.<A, C>left(e.left().value()));
       }
 
       public <C> P1<Either<A, C>> traverseP1(final F<B, P1<C>> f) {
@@ -890,8 +890,8 @@ public abstract class Either<A, B> {
    * @param left  The left value to use if the condition does not satisfy.
    * @return A constructed either based on the given condition.
    */
-  public static <A, B> Either<A, B> iif(final boolean c, final P1<B> right, final P1<A> left) {
-    return c ? new Right<A, B>(right._1()) : new Left<A, B>(left._1());
+  public static <A, B> Either<A, B> iif(final boolean c, final F0<B> right, final F0<A> left) {
+    return c ? new Right<A, B>(right.f()) : new Left<A, B>(left.f());
   }
 
   /**

--- a/core/src/main/java/fj/data/IOFunctions.java
+++ b/core/src/main/java/fj/data/IOFunctions.java
@@ -39,8 +39,8 @@ public class IOFunctions {
         return Try.f(toTry(io));
     }
 
-    public static <A> IO<A> io(P1<A> p) {
-        return () -> p._1();
+    public static <A> IO<A> io(F0<A> p) {
+        return p::f;
     }
 
     public static <A> IO<A> io(Try0<A, ? extends IOException> t) {
@@ -150,8 +150,8 @@ public class IOFunctions {
     };
   }
 
-	public static final <A> IO<A> lazy(final P1<A> p) {
-		return () -> p._1();
+	public static final <A> IO<A> lazy(final F0<A> p) {
+		return io(p);
 	}
 
     public static final <A> IO<A> lazy(final F<Unit, A> f) {
@@ -162,8 +162,8 @@ public class IOFunctions {
         return () -> f.f(Unit.unit());
     }
 
-    public static final <A> SafeIO<A> lazySafe(final P1<A> f) {
-        return () -> f._1();
+    public static final <A> SafeIO<A> lazySafe(final F0<A> f) {
+        return f::f;
     }
 
     /**
@@ -344,7 +344,7 @@ public class IOFunctions {
 
 	public static <A> IO<Stream<A>> sequence(Stream<IO<A>> stream) {
 		F2<IO<Stream<A>>, IO<A>, IO<Stream<A>>> f2 = (ioList, io) ->
-			IOFunctions.bind(ioList, (xs) -> map(io, x -> Stream.cons(x, P.lazy(u -> xs))));
+			IOFunctions.bind(ioList, (xs) -> map(io, x -> Stream.cons(x, P.lazy(() -> xs))));
 		return stream.foldLeft(f2, IOFunctions.unit(Stream.<A>nil()));
 	}
 

--- a/core/src/main/java/fj/data/Java.java
+++ b/core/src/main/java/fj/data/Java.java
@@ -1738,7 +1738,7 @@ public final class Java {
 // BEGIN Future ->
 
   public static <A> F<Future<A>, P1<Either<Exception, A>>> Future_P1() {
-    return a -> P.lazy(u -> {
+    return a -> P.lazy(() -> {
         Either<Exception, A> r;
         try {
           r = Either.right(a.get());

--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -1,6 +1,7 @@
 package fj.data;
 
 import static fj.Bottom.error;
+import fj.F0;
 import fj.F2Functions;
 import fj.Equal;
 import fj.F;
@@ -28,7 +29,6 @@ import static fj.data.Option.some;
 import static fj.function.Booleans.not;
 import static fj.Ordering.GT;
 import static fj.Ord.intOrd;
-
 import fj.Ordering;
 import fj.control.Trampoline;
 import fj.function.Effect1;
@@ -118,8 +118,8 @@ public abstract class List<A> implements Iterable<A> {
    * @param a The argument to return if this list is empty.
    * @return The head of this list if there is one or the given argument if this list is empty.
    */
-  public final A orHead(final P1<A> a) {
-    return isEmpty() ? a._1() : head();
+  public final A orHead(final F0<A> a) {
+    return isEmpty() ? a.f() : head();
   }
 
   /**
@@ -128,8 +128,8 @@ public abstract class List<A> implements Iterable<A> {
    * @param as The argument to return if this list is empty.
    * @return The tail of this list if there is one or the given argument if this list is empty.
    */
-  public final List<A> orTail(final P1<List<A>> as) {
-    return isEmpty() ? as._1() : tail();
+  public final List<A> orTail(final F0<List<A>> as) {
+    return isEmpty() ? as.f() : tail();
   }
 
   /**
@@ -149,8 +149,8 @@ public abstract class List<A> implements Iterable<A> {
    * @param x The value to return in left if this list is empty.
    * @return An either projection of this list.
    */
-  public final <X> Either<X, A> toEither(final P1<X> x) {
-    return isEmpty() ? Either.<X, A>left(x._1()) : Either.<X, A>right(head());
+  public final <X> Either<X, A> toEither(final F0<X> x) {
+    return isEmpty() ? Either.<X, A>left(x.f()) : Either.<X, A>right(head());
   }
 
   /**
@@ -1877,7 +1877,7 @@ public abstract class List<A> implements Iterable<A> {
         //Casting to List<A> here does not cause a runtime exception even if the type arguments don't match.
         //The cast is done to avoid the compiler warning "raw use of parameterized class 'List'"
 
-        return Equal.shallowEqualsO(this, obj).orSome(P.lazy(u -> Equal.listEqual(Equal.<A>anyEqual()).eq(this, (List<A>) obj)));
+        return Equal.shallowEqualsO(this, obj).orSome(() -> Equal.listEqual(Equal.<A>anyEqual()).eq(this, (List<A>) obj));
     }
 
     /**

--- a/core/src/main/java/fj/data/Option.java
+++ b/core/src/main/java/fj/data/Option.java
@@ -1,8 +1,8 @@
 package fj.data;
 
 import static fj.Bottom.error;
-
 import fj.F;
+import fj.F0;
 import fj.F2;
 import fj.P;
 import fj.P1;
@@ -19,7 +19,6 @@ import fj.function.Effect1;
 import fj.Equal;
 import fj.Ord;
 import fj.Hash;
-
 import static fj.Function.*;
 import static fj.P.p;
 import static fj.Unit.unit;
@@ -130,8 +129,8 @@ public abstract class Option<A> implements Iterable<A> {
    * @param f The function to apply to the value of this optional value.
    * @return A reduction on this optional value.
    */
-  public final <B> B option(final P1<B> b, final F<A, B> f) {
-    return isSome() ? f.f(some()) : b._1();
+  public final <B> B option(final F0<B> b, final F<A, B> f) {
+    return isSome() ? f.f(some()) : b.f();
   }
 
   /**
@@ -149,8 +148,8 @@ public abstract class Option<A> implements Iterable<A> {
    * @param a The argument to return if this optiona value has no value.
    * @return The value of this optional value or the given argument.
    */
-  public final A orSome(final P1<A> a) {
-    return isSome() ? some() : a._1();
+  public final A orSome(final F0<A> a) {
+    return isSome() ? some() : a.f();
   }
 
   /**
@@ -169,11 +168,11 @@ public abstract class Option<A> implements Iterable<A> {
    * @param message The message to fail with if this optional value has no value.
    * @return The value of this optional value if there there is one.
    */
-  public final A valueE(final P1<String> message) {
+  public final A valueE(final F0<String> message) {
     if(isSome())
       return some();
     else
-      throw error(message._1());
+      throw error(message.f());
   }
 
   /**
@@ -421,7 +420,7 @@ public abstract class Option<A> implements Iterable<A> {
   }
 
   public <B> IO<Option<B>> traverseIO(F<A, IO<B>> f) {
-    return map(a -> IOFunctions.map(f.f(a), b -> some(b))).orSome(IOFunctions.lazy(u -> none()));
+    return map(a -> IOFunctions.map(f.f(a), b -> some(b))).orSome(IOFunctions.lazy(() -> none()));
   }
 
   public <B> List<Option<B>> traverseList(F<A, List<B>> f) {
@@ -482,8 +481,8 @@ public abstract class Option<A> implements Iterable<A> {
    * @param o The optional value to return if this optional value has no value.
    * @return This optional value if there is one, otherwise, returns the argument optional value.
    */
-  public final Option<A> orElse(final P1<Option<A>> o) {
-    return isSome() ? this : o._1();
+  public final Option<A> orElse(final F0<Option<A>> o) {
+    return isSome() ? this : o.f();
   }
 
   /**
@@ -503,8 +502,8 @@ public abstract class Option<A> implements Iterable<A> {
    * @param x The value to return in left if this optional value has no value.
    * @return An either projection of this optional value.
    */
-  public final <X> Either<X, A> toEither(final P1<X> x) {
-    return isSome() ? Either.<X, A>right(some()) : Either.<X, A>left(x._1());
+  public final <X> Either<X, A> toEither(final F0<X> x) {
+    return isSome() ? Either.<X, A>right(some()) : Either.<X, A>left(x.f());
   }
 
   /**
@@ -626,7 +625,7 @@ public abstract class Option<A> implements Iterable<A> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.optionEqual(Equal.<A>anyEqual()).eq(this, (Option<A>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.optionEqual(Equal.<A>anyEqual()).eq(this, (Option<A>) other));
   }
 
   /**
@@ -751,8 +750,8 @@ public abstract class Option<A> implements Iterable<A> {
    * @return An optional value that has a value of the given argument if the given boolean is true, otherwise, returns
    *         no value.
    */
-  public static <A> Option<A> iif(final boolean p, final P1<A> a) {
-    return p ? some(a._1()) : Option.<A>none();
+  public static <A> Option<A> iif(final boolean p, final F0<A> a) {
+    return p ? some(a.f()) : Option.<A>none();
   }
 
   /**

--- a/core/src/main/java/fj/data/Seq.java
+++ b/core/src/main/java/fj/data/Seq.java
@@ -48,7 +48,7 @@ public final class Seq<A> {
   @Override
   public boolean equals(Object other) {
 
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.seqEqual(Equal.<A>anyEqual()).eq(this, (Seq<A>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.seqEqual(Equal.<A>anyEqual()).eq(this, (Seq<A>) other));
   }
 
   /**

--- a/core/src/main/java/fj/data/Set.java
+++ b/core/src/main/java/fj/data/Set.java
@@ -142,7 +142,7 @@ public abstract class Set<A> implements Iterable<A> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.setEqual(Equal.<A>anyEqual()).eq(this, (Set<A>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.setEqual(Equal.<A>anyEqual()).eq(this, (Set<A>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/data/Stream.java
+++ b/core/src/main/java/fj/data/Stream.java
@@ -1,6 +1,7 @@
 package fj.data;
 
 import fj.Equal;
+import fj.F0;
 import fj.Hash;
 import fj.Show;
 import fj.F;
@@ -207,8 +208,8 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param a The argument to return if this stream is empty.
    * @return The head of this stream if there is one or the given argument if this stream is empty.
    */
-  public final A orHead(final P1<A> a) {
-    return isEmpty() ? a._1() : head();
+  public final A orHead(final F0<A> a) {
+    return isEmpty() ? a.f() : head();
   }
 
   /**
@@ -325,8 +326,8 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param as The stream to append to this one.
    * @return A new stream that has appended the given stream.
    */
-  public final Stream<A> append(final P1<Stream<A>> as) {
-    return isEmpty() ? as._1() : cons(head(), new P1<Stream<A>>() {
+  public final Stream<A> append(final F0<Stream<A>> as) {
+    return isEmpty() ? as.f() : cons(head(), new P1<Stream<A>>() {
       public Stream<A> _1() {
         return tail()._1().append(as);
       }
@@ -900,8 +901,8 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param x The value to return in left if this stream is empty.
    * @return An either projection of this stream.
    */
-  public final <X> Either<X, A> toEither(final P1<X> x) {
-    return isEmpty() ? Either.<X, A>left(x._1()) : Either.<X, A>right(head());
+  public final <X> Either<X, A> toEither(final F0<X> x) {
+    return isEmpty() ? Either.<X, A>left(x.f()) : Either.<X, A>right(head());
   }
 
   /**
@@ -1029,12 +1030,8 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param a The element to append.
    * @return A new stream with the given element at the end.
    */
-  public final Stream<A> snoc(final P1<A> a) {
-    return append(new P1<Stream<A>>() {
-      public Stream<A> _1() {
-        return single(a._1());
-      }
-    });
+  public final Stream<A> snoc(final F0<A> a) {
+    return append(() -> single(a.f()));
   }
 
   /**
@@ -1247,7 +1244,7 @@ public abstract class Stream<A> implements Iterable<A> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.streamEqual(Equal.<A>anyEqual()).eq(this, (Stream<A>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.streamEqual(Equal.<A>anyEqual()).eq(this, (Stream<A>) other));
   }
 
   @Override
@@ -1323,11 +1320,7 @@ public abstract class Stream<A> implements Iterable<A> {
         return nil();
       }
     });
-    return isEmpty() ? nil : nil.append(new P1<Stream<Stream<A>>>() {
-      public Stream<Stream<A>> _1() {
-        return tail()._1().inits().map(Stream.<A>cons_().f(head()));
-      }
-    });
+    return isEmpty() ? nil : nil.append(() -> tail()._1().inits().map(Stream.<A>cons_().f(head())));
   }
 
   /**
@@ -1624,7 +1617,7 @@ public abstract class Stream<A> implements Iterable<A> {
   public static <A> Stream<A> iteratorStream(final Iterator<A> i) {
     if (i.hasNext()) {
       final A a = i.next();
-      return cons(a, P.lazy(u -> iteratorStream(i)));
+      return cons(a, P.lazy(() -> iteratorStream(i)));
     } else
       return nil();
   }
@@ -1653,11 +1646,7 @@ public abstract class Stream<A> implements Iterable<A> {
     if (as.isEmpty())
       throw error("cycle on empty list");
     else
-      return as.append(new P1<Stream<A>>() {
-        public Stream<A> _1() {
-          return cycle(as);
-        }
-      });
+      return as.append(() -> cycle(as));
   }
 
   /**

--- a/core/src/main/java/fj/data/Tree.java
+++ b/core/src/main/java/fj/data/Tree.java
@@ -261,7 +261,7 @@ public final class Tree<A> implements Iterable<A> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.treeEqual(Equal.<A>anyEqual()).eq(this, (Tree<A>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.treeEqual(Equal.<A>anyEqual()).eq(this, (Tree<A>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -38,7 +38,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.treeMapEqual(Equal.<K>anyEqual(), Equal.<V>anyEqual()).eq(this, (TreeMap<K, V>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.treeMapEqual(Equal.<K>anyEqual(), Equal.<V>anyEqual()).eq(this, (TreeMap<K, V>) other));
   }
 
   @Override

--- a/core/src/main/java/fj/data/Validation.java
+++ b/core/src/main/java/fj/data/Validation.java
@@ -103,7 +103,7 @@ public class Validation<E, T> implements Iterable<T> {
    * @param err The error message to fail with.
    * @return The success value.
    */
-  public T successE(final P1<String> err) {
+  public T successE(final F0<String> err) {
     return e.right().valueE(err);
   }
 
@@ -123,7 +123,7 @@ public class Validation<E, T> implements Iterable<T> {
    * @param t The value to return if this is failure.
    * @return The success value or the given value.
    */
-  public T orSuccess(final P1<T> t) {
+  public T orSuccess(final F0<T> t) {
     return e.right().orValue(t);
   }
 
@@ -252,7 +252,7 @@ public class Validation<E, T> implements Iterable<T> {
 
   @Override
   public boolean equals(Object other) {
-    return Equal.shallowEqualsO(this, other).orSome(P.lazy(u -> Equal.validationEqual(Equal.<E>anyEqual(), Equal.<T>anyEqual()).eq(this, (Validation<E, T>) other)));
+    return Equal.shallowEqualsO(this, other).orSome(() -> Equal.validationEqual(Equal.<E>anyEqual(), Equal.<T>anyEqual()).eq(this, (Validation<E, T>) other));
   }
 
   @Override
@@ -880,7 +880,7 @@ public class Validation<E, T> implements Iterable<T> {
      * @param err The error message to fail with.
      * @return The failing value.
      */
-    public E failE(final P1<String> err) {
+    public E failE(final F0<String> err) {
       return v.toEither().left().valueE(err);
     }
 
@@ -900,7 +900,7 @@ public class Validation<E, T> implements Iterable<T> {
      * @param e The value to return if this is success.
      * @return The failing value or the given value.
      */
-    public E orFail(final P1<E> e) {
+    public E orFail(final F0<E> e) {
       return v.toEither().left().orValue(e);
     }
 

--- a/core/src/main/java/fj/data/vector/V.java
+++ b/core/src/main/java/fj/data/vector/V.java
@@ -1,5 +1,6 @@
 package fj.data.vector;
 
+import fj.F0;
 import fj.F2;
 import fj.F3;
 import fj.F4;
@@ -34,14 +35,14 @@ public final class V {
    * @param a2 An element to put in a vector.
    * @return The vector-2.
    */
-  public static <A> V2<A> v(final P1<A> a1, final P1<A> a2) {
+  public static <A> V2<A> v(final F0<A> a1, final F0<A> a2) {
     return V2.p(new P2<A, A>() {
       public A _1() {
-        return a1._1();
+        return a1.f();
       }
 
       public A _2() {
-        return a2._1();
+        return a2.f();
       }
     });
   }
@@ -52,11 +53,7 @@ public final class V {
    * @return A function that puts elements in a vector-2.
    */
   public static <A> F2<A, A, V2<A>> v2() {
-    return new F2<A, A, V2<A>>() {
-      public V2<A> f(final A a, final A a1) {
-        return v(a, a1);
-      }
-    };
+    return (a, a1) -> v(a, a1);
   }
 
   /**
@@ -79,7 +76,7 @@ public final class V {
    * @param a3 An element to put in a vector.
    * @return The vector-3.
    */
-  public static <A> V3<A> v(final P1<A> a1, final P1<A> a2, final P1<A> a3) {
+  public static <A> V3<A> v(final P1<A> a1, final F0<A> a2, final F0<A> a3) {
     return V3.cons(a1, v(a2, a3));
   }
 
@@ -89,11 +86,7 @@ public final class V {
    * @return A function that puts elements in a vector-3.
    */
   public static <A> F3<A, A, A, V3<A>> v3() {
-    return new F3<A, A, A, V3<A>>() {
-      public V3<A> f(final A a, final A a1, final A a2) {
-        return v(a, a1, a2);
-      }
-    };
+    return (a, a1, a2) -> v(a, a1, a2);
   }
 
   /**
@@ -118,7 +111,7 @@ public final class V {
    * @param a4 An element to put in a vector.
    * @return The vector-4.
    */
-  public static <A> V4<A> v(final P1<A> a1, final P1<A> a2, final P1<A> a3, final P1<A> a4) {
+  public static <A> V4<A> v(final P1<A> a1, final P1<A> a2, final F0<A> a3, final F0<A> a4) {
     return V4.cons(a1, v(a2, a3, a4));
   }
 
@@ -128,11 +121,7 @@ public final class V {
    * @return A function that puts elements in a vector-4.
    */
   public static <A> F4<A, A, A, A, V4<A>> v4() {
-    return new F4<A, A, A, A, V4<A>>() {
-      public V4<A> f(final A a, final A a1, final A a2, final A a3) {
-        return v(a, a1, a2, a3);
-      }
-    };
+    return (a, a1, a2, a3) -> v(a, a1, a2, a3);
   }
 
 
@@ -160,7 +149,7 @@ public final class V {
    * @param a5 An element to put in a vector.
    * @return The vector-5.
    */
-  public static <A> V5<A> v(final P1<A> a1, final P1<A> a2, final P1<A> a3, final P1<A> a4, final P1<A> a5) {
+  public static <A> V5<A> v(final P1<A> a1, final P1<A> a2, final P1<A> a3, final F0<A> a4, final F0<A> a5) {
     return V5.cons(a1, v(a2, a3, a4, a5));
   }
 
@@ -170,11 +159,7 @@ public final class V {
    * @return A function that puts elements in a vector-5.
    */
   public static <A> F5<A, A, A, A, A, V5<A>> v5() {
-    return new F5<A, A, A, A, A, V5<A>>() {
-      public V5<A> f(final A a, final A a1, final A a2, final A a3, final A a4) {
-        return v(a, a1, a2, a3, a4);
-      }
-    };
+    return (a, a1, a2, a3, a4) -> v(a, a1, a2, a3, a4);
   }
 
 }

--- a/core/src/main/java/fj/function/Visitor.java
+++ b/core/src/main/java/fj/function/Visitor.java
@@ -2,6 +2,7 @@ package fj.function;
 
 import fj.Equal;
 import fj.F;
+import fj.F0;
 import fj.F2;
 import fj.Function;
 import fj.Monoid;
@@ -9,7 +10,6 @@ import fj.P1;
 import fj.P2;
 import fj.data.List;
 import fj.data.Option;
-
 import static fj.Function.compose;
 import static fj.Function.curry;
 import static fj.data.List.lookup;
@@ -31,7 +31,7 @@ public final class Visitor {
    * @param def The default value if no value is found in the list.
    * @return The first value available in the given list of optional values. If none is found return the given default value.
    */
-  public static <X> X findFirst(final List<Option<X>> values, final P1<X> def) {
+  public static <X> X findFirst(final List<Option<X>> values, final F0<X> def) {
     return Monoid.<X>firstOptionMonoid().sumLeft(values).orSome(def);
   }
 
@@ -42,7 +42,7 @@ public final class Visitor {
    * @param def The default value if no value is found in the list.
    * @return The first non-<code>null</code> value in the given list of optional values. If none is found return the given default value.
    */
-  public static <X> X nullablefindFirst(final List<X> values, final P1<X> def) {
+  public static <X> X nullablefindFirst(final List<X> values, final F0<X> def) {
     return findFirst(values.map(Option.<X>fromNull()), def);
   }
 
@@ -56,7 +56,7 @@ public final class Visitor {
    * @return The first value found in the list of visitors after application of the given value, otherwise returns the
    * given default.
    */
-  public static <A, B> B visitor(final List<F<A, Option<B>>> visitors, final P1<B> def, final A value) {
+  public static <A, B> B visitor(final List<F<A, Option<B>>> visitors, final F0<B> def, final A value) {
     return findFirst(visitors.map(Function.<A, Option<B>>apply(value)), def);
   }
 
@@ -70,7 +70,7 @@ public final class Visitor {
    * @return The first value found in the list of visitors after application of the given value, otherwise returns the
    * given default.
    */
-  public static <A, B> B nullableVisitor(final List<F<A, B>> visitors, final P1<B> def, final A value) {
+  public static <A, B> B nullableVisitor(final List<F<A, B>> visitors, final F0<B> def, final A value) {
     return visitor(visitors.map(new F<F<A, B>, F<A, Option<B>>>() {
       public F<A, Option<B>> f(final F<A, B> k) {
         return compose(Option.<B>fromNull(), k);

--- a/core/src/main/java/fj/test/Bool.java
+++ b/core/src/main/java/fj/test/Bool.java
@@ -1,5 +1,6 @@
 package fj.test;
 
+import fj.F0;
 import fj.P1;
 import static fj.test.Property.prop;
 
@@ -43,7 +44,7 @@ public final class Bool {
    * @param p The property to return if this value is true.
    * @return a property that produces a result only if this value is true.
    */
-  public Property implies(final P1<Property> p) {
+  public Property implies(final F0<Property> p) {
     return Property.implies(b, p);
   }
 

--- a/core/src/main/java/fj/test/Property.java
+++ b/core/src/main/java/fj/test/Property.java
@@ -128,7 +128,7 @@ public final class Property {
    * @param r             The random generator to use for checking.
    * @param minSuccessful The minimum number of successful tests before a result is reached.
    * @param maxDiscarded  The maximum number of tests discarded because they did not satisfy
-   *                      pre-conditions (i.e. {@link #implies(boolean, P1)}).
+   *                      pre-conditions (i.e. {@link #implies(boolean, F0)}).
    * @param minSize       The minimum size to use for checking.
    * @param maxSize       The maximum size to use for checking.
    * @return A result after checking this property.
@@ -189,7 +189,7 @@ public final class Property {
    *
    * @param minSuccessful The minimum number of successful tests before a result is reached.
    * @param maxDiscarded  The maximum number of tests discarded because they did not satisfy
-   *                      pre-conditions (i.e. {@link #implies(boolean, P1)}).
+   *                      pre-conditions (i.e. {@link #implies(boolean, F0)}).
    * @param minSize       The minimum size to use for checking.
    * @param maxSize       The maximum size to use for checking.
    * @return A result after checking this property.
@@ -276,7 +276,7 @@ public final class Property {
    * successful checks, the given maximum discarded tests, minimum size of 0, maximum size of 100.
    *
    * @param maxDiscarded The maximum number of tests discarded because they did not satisfy
-   *                     pre-conditions (i.e. {@link #implies(boolean, P1)}).
+   *                     pre-conditions (i.e. {@link #implies(boolean, F0)}).
    * @return A result after checking this property.
    */
   public CheckResult maxDiscarded(final int maxDiscarded) {
@@ -289,7 +289,7 @@ public final class Property {
    *
    * @param r            The random generator.
    * @param maxDiscarded The maximum number of tests discarded because they did not satisfy
-   *                     pre-conditions (i.e. {@link #implies(boolean, P1)}).
+   *                     pre-conditions (i.e. {@link #implies(boolean, F0)}).
    * @return A result after checking this property.
    */
   public CheckResult maxDiscarded(final Rand r, final int maxDiscarded) {
@@ -350,8 +350,8 @@ public final class Property {
    * @param p The property to return if the condition satisfies.
    * @return A property that produces a result only if the given condition satisfies.
    */
-  public static Property implies(final boolean b, final P1<Property> p) {
-    return b ? p._1() : new Property(new F<Integer, F<Rand, Result>>() {
+  public static Property implies(final boolean b, final F0<Property> p) {
+    return b ? p.f() : new Property(new F<Integer, F<Rand, Result>>() {
       public F<Rand, Result> f(final Integer i) {
         return new F<Rand, Result>() {
           public Result f(final Rand r) {
@@ -457,11 +457,7 @@ public final class Property {
                   public Boolean f(final Option<P2<A, Result>> o) {
                     return failed(o);
                   }
-                }).orSome(new P1<Option<P2<A, Result>>>() {
-                  public Option<P2<A, Result>> _1() {
-                    return results.head();
-                  }
-                });
+                }).orSome(() -> results.head());
               }
 
               public boolean failed(final Option<P2<A, Result>> o) {
@@ -1640,9 +1636,9 @@ public final class Property {
    * @return A property that has a result of exception, if the evaluation of the given property
    *         throws an exception; otherwise, the given property is returned.
    */
-  public static Property exception(final P1<Property> p) {
+  public static Property exception(final F0<Property> p) {
     try {
-      return p._1();
+      return p.f();
     } catch (final Throwable t) {
       return new Property(new F<Integer, F<Rand, Result>>() {
         public F<Rand, Result> f(final Integer i) {

--- a/core/src/main/java/fj/test/Result.java
+++ b/core/src/main/java/fj/test/Result.java
@@ -157,11 +157,7 @@ public final class Result {
    * @return The result that may be {@link #noResult() noResult()}.
    */
   public static Result noResult(final Option<Result> r) {
-    return r.orSome(new P1<Result>() {
-      public Result _1() {
-        return noResult();
-      }
-    });
+    return r.orSome(() -> noResult());
   }
 
   /**

--- a/core/src/main/java/fj/test/Shrink.java
+++ b/core/src/main/java/fj/test/Shrink.java
@@ -138,9 +138,9 @@ public final class Shrink<A> {
     if (i == 0L)
       return nil();
     else {
-      final Stream<Long> is = cons(0L, P.lazy(u -> iterate(x -> x / 2L, i).takeWhile(x2 -> x2 != 0L).map(x1 -> i - x1)));
+      final Stream<Long> is = cons(0L, P.lazy(() -> iterate(x -> x / 2L, i).takeWhile(x2 -> x2 != 0L).map(x1 -> i - x1)));
 
-      return i < 0L ? cons(-i, P.lazy(u -> is)) : is;
+      return i < 0L ? cons(-i, P.lazy(() -> is)) : is;
     }
   });
 
@@ -231,10 +231,10 @@ public final class Shrink<A> {
           final F<List<A>, Boolean> isNotEmpty = isNotEmpty_();
           return cons(
                   as1,
-                  P.lazy(u ->
+                  P.lazy(() ->
                   {
                           final List<A> as2 = as.drop(n1);
-                          return cons(as2, P.lazy(u1 -> removeChunks(n1, as1)
+                          return cons(as2, P.lazy(() -> removeChunks(n1, as1)
                                                            .filter(isNotEmpty)
                                                            .map(aas1 -> aas1.append(as2))
                                                            .interleave(removeChunks(n2, as2)

--- a/core/src/main/java/fj/test/reflect/CheckParams.java
+++ b/core/src/main/java/fj/test/reflect/CheckParams.java
@@ -29,10 +29,10 @@ public @interface CheckParams {
 
   /**
    * The maximum number of tests discarded because they did not satisfy pre-conditions
-   * (i.e. {@link Property#implies(boolean, P1)}).
+   * (i.e. {@link Property#implies(boolean, F0)}).
    *
    * @return The maximum number of tests discarded because they did not satisfy pre-conditions
-   * (i.e. {@link Property#implies(boolean, P1)}).
+   * (i.e. {@link Property#implies(boolean, F0)}).
    */
   int maxDiscarded() default 500;
 

--- a/java8/src/main/java/fj/data/Java8.java
+++ b/java8/src/main/java/fj/data/Java8.java
@@ -1,19 +1,22 @@
 package fj.data;
 
-import fj.*;
-import fj.function.Try0;
-import fj.function.Try1;
-import fj.function.Try2;
-
 import java.util.Iterator;
 import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
+
+import fj.F;
+import fj.F2;
+import fj.P;
+import fj.P1;
+import fj.Try;
+import fj.Unit;
+import fj.function.Try0;
+import fj.function.Try1;
+import fj.function.Try2;
 
 /**
  * Created by mperry on 3/06/2014.
@@ -29,7 +32,7 @@ public final class Java8 {
     }
 
     public static <A> F<Supplier<A>, P1<A>> Supplier_P1() {
-        return s -> P.lazy(u -> s.get());
+        return s -> P.lazy(() -> s.get());
     }
 
     public static <A> Supplier<A> P1_Supplier(final P1<A> p) {
@@ -96,7 +99,7 @@ public final class Java8 {
         return t -> (a, b) -> Try.f(t).f(a, b);
     }
 
-    public static <A> java.util.stream.Stream<A> List_JavaStream(List<A> list) {
+    public static <A> java.util.stream.Stream<A> List_JavaStream(final List<A> list) {
         return Iterable_JavaStream(list);
     }
 
@@ -120,22 +123,22 @@ public final class Java8 {
         return c -> Consumer_F(c);
     }
 
-    public static <A> F<A, Unit> Consumer_F(Consumer<A> c) {
+    public static <A> F<A, Unit> Consumer_F(final Consumer<A> c) {
         return a -> {
             c.accept(a);
             return Unit.unit();
         };
     }
 
-    static public <A> java.util.stream.Stream<A> Stream_JavaStream(fj.data.Stream<A> s) {
+    static public <A> java.util.stream.Stream<A> Stream_JavaStream(final fj.data.Stream<A> s) {
         return Iterable_JavaStream(s);
     }
 
-    static public <A> java.util.stream.Stream<A> Iterable_JavaStream(Iterable<A> it) {
+    static public <A> java.util.stream.Stream<A> Iterable_JavaStream(final Iterable<A> it) {
         return StreamSupport.stream(it.spliterator(), false);
     }
 
-    static public <A> java.util.stream.Stream<A> Iterator_JavaStream(Iterator<A> it) {
+    static public <A> java.util.stream.Stream<A> Iterator_JavaStream(final Iterator<A> it) {
         return Iterable_JavaStream(() -> it);
     }
 
@@ -143,15 +146,15 @@ public final class Java8 {
         return s -> Stream_JavaStream(s);
     }
 
-    static public <A> Stream<A> JavaStream_Stream(java.util.stream.Stream<A> s) {
+    static public <A> Stream<A> JavaStream_Stream(final java.util.stream.Stream<A> s) {
         return s.collect(Collectors.toStream());
     }
 
-    static public <A> List<A> JavaStream_List(java.util.stream.Stream<A> s) {
+    static public <A> List<A> JavaStream_List(final java.util.stream.Stream<A> s) {
         return s.collect(Collectors.toList());
     }
 
-    static public <A> Array<A> JavaStream_Array(java.util.stream.Stream<A> s) {
+    static public <A> Array<A> JavaStream_Array(final java.util.stream.Stream<A> s) {
         return s.collect(Collectors.toArray());
     }
 


### PR DESCRIPTION
whenever it safe to do so without breaking source compatibility.
This should improve overall support for java8 lambda syntax.