### PR TITLE
Added missing functionality for FingerTree and Seq

### DIFF
--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -1,13 +1,10 @@
 package fj.data;
 
-import fj.Equal;
-import fj.F;
-import fj.F2;
+import fj.*;
+
 import static fj.Function.compose;
 import static fj.Function.curry;
 import static fj.P.p;
-import fj.P1;
-import fj.P2;
 import static fj.data.Option.none;
 import static fj.data.Option.some;
 import static fj.data.Stream.join;
@@ -108,7 +105,9 @@ public final class LazyString implements CharSequence {
    * @return The String representation of this lazy string.
    */
   public String toString() {
-    return new StringBuilder(length() + 16).append(this).toString();
+    final StringBuilder builder = new StringBuilder(length() + 16);
+    s.foreachDoEffect(c -> builder.append(c.charValue()));
+    return builder.toString();
   }
 
   /**

--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -159,8 +159,7 @@ public abstract class List<A> implements Iterable<A> {
    * @return A stream projection of this list.
    */
   public final Stream<A> toStream() {
-    final Stream<A> nil = Stream.nil();
-    return foldRight(a -> as -> as.cons(a), nil);
+    return isEmpty() ? Stream.nil() : Stream.cons(head(), P.lazy(() -> tail().toStream()));
   }
 
   /**
@@ -1569,7 +1568,11 @@ public abstract class List<A> implements Iterable<A> {
    *         <code>to</code> value (exclusive).
    */
   public static List<Integer> range(final int from, final int to) {
-    return from >= to ? List.<Integer>nil() : cons(from, range(from + 1, to));
+    final Buffer<Integer> buf = Buffer.empty();
+    for (int i = from; i < to; i++) {
+      buf.snoc(i);
+    }
+    return buf.toList();
   }
 
   /**

--- a/core/src/main/java/fj/data/Seq.java
+++ b/core/src/main/java/fj/data/Seq.java
@@ -211,10 +211,25 @@ public final class Seq<A> implements Iterable<A> {
    * @return The element at the given index, or throws an error if the index is out of bounds.
    */
   public A index(final int i) {
-    if (i < 0 || i >= length())
-      throw error("Index " + i + " is out of bounds.");
+    checkBounds(i);
     return ftree.lookup(Function.<Integer>identity(), i)._2();
   }
+
+  /**
+   * Replace the element at the given index with the supplied value. This is an O(log(n)) operation.
+   *
+   * @param i The index of the element to update.
+   * @param a The new value.
+   *
+   * @return The updated sequence, or throws an error if the index is out of bounds.
+   */
+  public Seq<A> update(final int i, final A a) {
+    checkBounds(i);
+    final P3<FingerTree<Integer, A>, A, FingerTree<Integer, A>> lxr = ftree.split1(index -> index > i);
+    return new Seq<>(lxr._1().append(lxr._3().cons(a)));
+  }
+
+  private void checkBounds(final int i) { if (i < 0 || i >= length()) throw error("Index " + i + " is out of bounds."); }
 
     public <B> B foldLeft(final F2<B, A, B> f, final B z) {
         return ftree.foldLeft(f, z);

--- a/core/src/main/java/fj/data/Seq.java
+++ b/core/src/main/java/fj/data/Seq.java
@@ -229,6 +229,24 @@ public final class Seq<A> implements Iterable<A> {
     return new Seq<>(lxr._1().append(lxr._3().cons(a)));
   }
 
+  /**
+   * Takes the given number of elements from the head of this sequence if they are available.
+   *
+   * @param n The maximum number of elements to take from this sequence.
+   * @return A sequence consisting only of the first n elements of this sequence, or else the whole sequence,
+   *   if it has less than n elements.
+   */
+  public Seq<A> take(final int n) { return split(n)._1(); }
+
+  /**
+   * Drops the given number of elements from the head of this sequence if they are available.
+   *
+   * @param n The number of elements to drop from this sequence.
+   * @return A sequence consisting of all elements of this sequence except the first n ones, or else the empty sequence,
+   *   if this sequence has less than n elements.
+   */
+  public Seq<A> drop(final int n) { return split(n)._2(); }
+
   private void checkBounds(final int i) { if (i < 0 || i >= length()) throw error("Index " + i + " is out of bounds."); }
 
     public <B> B foldLeft(final F2<B, A, B> f, final B z) {

--- a/core/src/main/java/fj/data/Stream.java
+++ b/core/src/main/java/fj/data/Stream.java
@@ -386,13 +386,7 @@ public abstract class Stream<A> implements Iterable<A> {
    * @return A new stream after performing the map, then final join.
    */
   public final <B> Stream<B> bind(final F<A, Stream<B>> f) {
-    return map(f).foldLeft((accumulator, element) -> {
-        Stream<B> result = accumulator;
-        for (B single : element) {
-            result = result.cons(single);
-        }
-        return result;
-    }, Stream.<B>nil()).reverse();
+    return foldRight(h -> (t -> f.f(h).append(t)), nil());
   }
 
   /**
@@ -1554,9 +1548,7 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param o The stream of streams to join.
    * @return A new stream that is the join of the given streams.
    */
-  public static <A> Stream<A> join(final Stream<Stream<A>> o) {
-    return Monoid.<A>streamMonoid().sumRight(o);
-  }
+  public static <A> Stream<A> join(final Stream<Stream<A>> o) { return o.bind(identity()); }
 
   /**
    * A first-class version of join

--- a/core/src/main/java/fj/data/fingertrees/Deep.java
+++ b/core/src/main/java/fj/data/fingertrees/Deep.java
@@ -1,8 +1,7 @@
 package fj.data.fingertrees;
 
-import fj.F;
-import fj.Function;
-import fj.P2;
+import fj.*;
+import fj.data.Option;
 import fj.data.vector.V2;
 import fj.data.vector.V3;
 import fj.data.vector.V4;
@@ -97,53 +96,59 @@ public final class Deep<V, A> extends FingerTree<V, A> {
     final Measured<V, A> m = measured();
     final V measure = m.sum(m.measure(a), v);
     final MakeTree<V, A> mk = mkTree(m);
-    return prefix.match(new F<One<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final One<V, A> one) {
-        return new Deep<V, A>(m, measure, mk.two(a, one.value()), middle, suffix);
-      }
-    }, new F<Two<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Two<V, A> two) {
-        return new Deep<V, A>(m, measure, mk.three(a, two.values()._1(), two.values()._2()), middle, suffix);
-      }
-    }, new F<Three<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Three<V, A> three) {
-        return new Deep<V, A>(m, measure, mk.four(a, three.values()._1(), three.values()._2(),
-                                                  three.values()._3()), middle, suffix);
-      }
-    }, new F<Four<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Four<V, A> four) {
-        return new Deep<V, A>(m, measure, mk.two(a, four.values()._1()),
-                              middle.cons(mk.node3(four.values()._2(), four.values()._3(), four.values()._4())),
-                              suffix);
-      }
-    });
+
+    return prefix.match(
+      one -> new Deep<>(m, measure, mk.two(a, one.value()), middle, suffix),
+      two -> new Deep<>(m, measure, mk.three(a, two.values()._1(), two.values()._2()), middle, suffix),
+      three -> new Deep<>(m, measure, mk.four(a, three.values()._1(), three.values()._2(), three.values()._3()), middle, suffix),
+      four -> new Deep<>(m, measure, mk.two(a, four.values()._1()), middle.cons(mk.node3(four.values()._2(), four.values()._3(), four.values()._4())), suffix));
   }
 
   public FingerTree<V, A> snoc(final A a) {
     final Measured<V, A> m = measured();
     final V measure = m.sum(m.measure(a), v);
     final MakeTree<V, A> mk = mkTree(m);
-    return suffix.match(new F<One<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final One<V, A> one) {
-        return new Deep<V, A>(m, measure, prefix, middle, mk.two(one.value(), a));
-      }
-    }, new F<Two<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Two<V, A> two) {
-        return new Deep<V, A>(m, measure, prefix, middle, mk.three(two.values()._1(), two.values()._2(), a));
-      }
-    }, new F<Three<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Three<V, A> three) {
-        return new Deep<V, A>(m, measure, prefix, middle, mk.four(three.values()._1(), three.values()._2(),
-                                                                  three.values()._3(), a));
-      }
-    }, new F<Four<V, A>, FingerTree<V, A>>() {
-      public FingerTree<V, A> f(final Four<V, A> four) {
-        return new Deep<V, A>(m, measure, prefix,
-                              middle.snoc(mk.node3(four.values()._1(), four.values()._2(), four.values()._3())),
-                              mk.two(four.values()._4(), a));
-      }
-    });
+
+    return suffix.match(
+      one -> new Deep<>(m, measure, prefix, middle, mk.two(one.value(), a)),
+      two -> new Deep<>(m, measure, prefix, middle, mk.three(two.values()._1(), two.values()._2(), a)),
+      three -> new Deep<>(m, measure, prefix, middle, mk.four(three.values()._1(), three.values()._2(), three.values()._3(), a)),
+      four -> new Deep<>(m, measure, prefix, middle.snoc(mk.node3(four.values()._1(), four.values()._2(), four.values()._3())), mk.two(four.values()._4(), a)));
   }
+
+  @Override public A head() {
+    return prefix.match(
+      One::value,
+      two -> two.values()._1(),
+      three -> three.values()._1(),
+      four -> four.values()._1());
+  }
+
+  @Override public A last() {
+    return suffix.match(
+      One::value,
+      two -> two.values()._2(),
+      three -> three.values()._3(),
+      four -> four.values()._4());
+  }
+
+  private static final <V, A> FingerTree<V, A> deepL(final Measured<V, A> measured, final Option<Digit<V, A>> lOpt, final FingerTree<V, Node<V, A>> m, final Digit<V, A> r) {
+    return lOpt.option(
+      P.lazy(() -> m.isEmpty() ? r.toTree() : mkTree(measured).deep(m.head().toDigit(), m.tail(), r)),
+      (F<Digit<V, A>, FingerTree<V, A>>) l -> mkTree(measured).deep(l, m, r)
+    );
+  }
+
+  private static final <V, A> FingerTree<V, A> deepR(final Measured<V, A> measured, final Option<Digit<V, A>> rOpt, final FingerTree<V, Node<V, A>> m, final Digit<V, A> l) {
+    return rOpt.option(
+      P.lazy(() -> m.isEmpty() ? l.toTree() : mkTree(measured).deep(l, m.init(), m.last().toDigit())),
+      (F<Digit<V, A>, FingerTree<V, A>>) r -> mkTree(measured).deep(l, m, r)
+    );
+  }
+
+  @Override public FingerTree<V, A> tail() { return deepL(measured(), prefix.tail(), middle, suffix); }
+
+  @Override public FingerTree<V, A> init() { return deepR(measured(), suffix.init(), middle, prefix); }
 
   @Override public FingerTree<V, A> append(final FingerTree<V, A> t) {
     final Measured<V, A> m = measured();
@@ -159,19 +164,38 @@ public final class Deep<V, A> extends FingerTree<V, A> {
     });
   }
 
-  @SuppressWarnings({"ReturnOfNull", "IfStatementWithIdenticalBranches"})
+  @Override P3<FingerTree<V, A>, A, FingerTree<V, A>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final V accL = m.sum(acc, prefix.measure());
+    if (predicate.f(accL)) {
+      final P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> lxr = prefix.split1(predicate, accL);
+      return P.p(lxr._1().option(new Empty<>(m), Digit::toTree), lxr._2(), deepL(m, lxr._3(), middle, suffix));
+    } else {
+      final V accM = m.sum(accL, middle.measure());
+      if (predicate.f(accM)) {
+        final P3<FingerTree<V, Node<V, A>>, Node<V, A>, FingerTree<V, Node<V, A>>> mlXsMr = middle.split1(predicate, accL);
+        final P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> lxr = mlXsMr._2().split1(predicate, m.sum(accL, mlXsMr._1().measure()));
+        return P.p(deepR(m, lxr._1(), mlXsMr._1(), prefix), lxr._2(), deepL(m, lxr._3(), mlXsMr._3(), suffix));
+      } else {
+        final P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> lxr = suffix.split1(predicate, accM);
+        return P.p(deepR(m, lxr._1(), middle, prefix), lxr._2(), lxr._3().option(new Empty<>(m), Digit::toTree));
+      }
+    }
+  }
+
   @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
     final int spr = o.f(prefix.measure());
-    final int spm = o.f(middle.measure());
-    if (i < spr)
-        return null; // TODO
-      //return prefix.lookup(o, i);
-    if (i < spm) {
-      return null; // TODO
-      /* final P2<Integer, Node<V, A>> p = middle.lookup(o, i - spr);
-      return p._2().lookup(o, p._1()); */
+    if (i < spr) {
+      return prefix.lookup(o, i);
+    } else {
+      final int spm = spr + o.f(middle.measure());
+      if (i < spm) {
+        final P2<Integer, Node<V, A>> p = middle.lookup(o, i - spr);
+        return p._2().lookup(o, p._1());
+      } else {
+        return suffix.lookup(o, i - spm);
+      }
     }
-    return null; // TODO suffix.lookup(i - spm);
   }
 
   private static <V, A> FingerTree<V, Node<V, A>> addDigits0(final Measured<V, A> m, final FingerTree<V, Node<V, A>> m1,

--- a/core/src/main/java/fj/data/fingertrees/Digit.java
+++ b/core/src/main/java/fj/data/fingertrees/Digit.java
@@ -1,11 +1,11 @@
 package fj.data.fingertrees;
 
-import fj.F;
-import fj.F2;
-import fj.Function;
+import fj.*;
+import fj.data.Option;
 import fj.data.vector.V2;
 import fj.data.vector.V3;
 import fj.data.vector.V4;
+
 import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
@@ -134,6 +134,8 @@ public abstract class Digit<V, A> {
     this.m = m;
   }
 
+  final Measured<V, A> measured() { return m; }
+
   /**
    * Returns the sum of the measurements of this digit according to the monoid.
    *
@@ -173,4 +175,26 @@ public abstract class Digit<V, A> {
       }
     });
   }
+
+  Option<Digit<V, A>> tail() {
+    return match(
+      one -> Option.<Digit<V, A>> none(),
+      two -> Option.<Digit<V, A>> some(mkTree(m).one(two.values()._2())),
+      three -> Option.<Digit<V, A>> some(mkTree(m).two(three.values()._2(), three.values()._3())),
+      four -> Option.<Digit<V, A>> some(mkTree(m).three(four.values()._2(), four.values()._3(), four.values()._4()))
+    );
+  }
+
+  Option<Digit<V, A>> init() {
+    return match(
+      one -> Option.<Digit<V, A>> none(),
+      two -> Option.<Digit<V, A>> some(mkTree(m).one(two.values()._1())),
+      three -> Option.<Digit<V, A>> some(mkTree(m).two(three.values()._1(), three.values()._2())),
+      four -> Option.<Digit<V, A>> some(mkTree(m).three(four.values()._1(), four.values()._2(), four.values()._3()))
+    );
+  }
+
+  abstract P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc);
+
+  public abstract P2<Integer, A> lookup(final F<V, Integer> o, final int i);
 }

--- a/core/src/main/java/fj/data/fingertrees/Empty.java
+++ b/core/src/main/java/fj/data/fingertrees/Empty.java
@@ -1,7 +1,10 @@
 package fj.data.fingertrees;
 
 import fj.F;
+import fj.P;
 import fj.P2;
+import fj.P3;
+
 import static fj.Bottom.error;
 
 /**
@@ -20,13 +23,19 @@ public final class Empty<V, A> extends FingerTree<V, A> {
     return cons(a);
   }
 
+  @Override public A head() { throw error("Selection of head in empty tree"); }
+
+  @Override public A last() { throw error("Selection of last in empty tree"); }
+
+  @Override public FingerTree<V, A> tail() { throw error("Selection of tail in empty tree"); }
+
+  @Override public FingerTree<V, A> init() { throw error("Selection of init in empty tree"); }
+
   @Override public FingerTree<V, A> append(final FingerTree<V, A> t) {
     return t;
   }
 
-  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
-    throw error("Lookup of empty tree.");
-  }
+  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) { throw error("Lookup of empty tree."); }
 
   @Override public <B> B foldRight(final F<A, F<B, B>> aff, final B z) {
     return z;
@@ -65,5 +74,7 @@ public final class Empty<V, A> extends FingerTree<V, A> {
     return empty.f(this);
   }
 
-
+  @Override P3<FingerTree<V, A>, A, FingerTree<V, A>> split1(final F<V, Boolean> predicate, final V acc) {
+    throw error("Splitting an empty tree");
+  }
 }

--- a/core/src/main/java/fj/data/fingertrees/FingerTree.java
+++ b/core/src/main/java/fj/data/fingertrees/FingerTree.java
@@ -1,6 +1,7 @@
 package fj.data.fingertrees;
 
 import fj.*;
+import fj.data.Option;
 import fj.data.Seq;
 
 /**
@@ -151,12 +152,67 @@ public abstract class FingerTree<V, A> {
   public abstract FingerTree<V, A> snoc(final A a);
 
   /**
+   * The first element of this tree. This is an O(1) operation.
+   *
+   * @return The first element if this tree is nonempty, otherwise throws an error.
+   */
+  public abstract A head();
+
+  /**
+   * The last element of this tree. This is an O(1) operation.
+   *
+   * @return The last element if this tree is nonempty, otherwise throws an error.
+   */
+  public abstract A last();
+
+  /**
+   * The tree without the first element. This is an O(1) operation.
+   *
+   * @return The tree without the first element if this tree is nonempty, otherwise throws an error.
+   */
+  public abstract FingerTree<V, A> tail();
+
+  /**
+   * The tree without the last element. This is an O(1) operation.
+   *
+   * @return The tree without the last element if this tree is nonempty, otherwise throws an error.
+   */
+  public abstract FingerTree<V, A> init();
+
+  /**
    * Appends one finger tree to another.
    *
    * @param t A finger tree to append to this one.
    * @return A new finger tree which is a concatenation of this tree and the given tree.
    */
   public abstract FingerTree<V, A> append(final FingerTree<V, A> t);
+
+  /**
+   * Splits this tree into a pair of subtrees at the point where the given predicate, based on the measure,
+   * changes from <code>false</code> to <code>true</code>. This is a O(log(n)) operation.
+   *
+   * @return Pair: the subtree containing elements before the point where <code>pred</code> first holds and the subtree
+   *   containing element at and after the point where <code>pred</code> first holds. Empty if <code>pred</code> never holds.
+   */
+  public final P2<FingerTree<V, A>, FingerTree<V, A>> split(final F<V, Boolean> predicate) {
+    if (!isEmpty() && predicate.f(measure())) {
+      final P3<FingerTree<V, A>, A, FingerTree<V, A>> lxr = split1(predicate);
+      return P.p(lxr._1(), lxr._3().cons(lxr._2()));
+    } else {
+      return P.p(this, mkTree(m).empty());
+    }
+  }
+
+  /**
+   * Like <code>split</code>, but returns the element where <code>pred</code> first holds separately.
+   *
+   * Throws an error if the tree is empty.
+   */
+  public final P3<FingerTree<V, A>, A, FingerTree<V, A>> split1(final F<V, Boolean> predicate) {
+    return split1(predicate, measured().zero());
+  }
+
+  abstract P3<FingerTree<V, A>, A, FingerTree<V, A>> split1(final F<V, Boolean> predicate, final V acc);
 
   public abstract P2<Integer, A> lookup(final F<V, Integer> o, final int i);
 }

--- a/core/src/main/java/fj/data/fingertrees/Four.java
+++ b/core/src/main/java/fj/data/fingertrees/Four.java
@@ -1,7 +1,15 @@
 package fj.data.fingertrees;
 
+import fj.P;
+import fj.P2;
+import fj.P3;
+import fj.data.Option;
 import fj.data.vector.V4;
 import fj.F;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
  * A four-element prefix or suffix of a finger tree.
@@ -35,5 +43,44 @@ public final class Four<V, A> extends Digit<V, A> {
    */
   public V4<A> values() {
     return as;
+  }
+
+  @Override P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final MakeTree<V, A> mk = mkTree(m);
+    final F<A, V> measure = m.measure();
+    final V acc1 = m.sum(acc, measure.f(as._1()));
+    if (predicate.f(acc1)) {
+      return P.p(none(), as._1(), some(mk.three(as._2(), as._3(), as._4())));
+    } else {
+      final V acc2 = m.sum(acc1, measure.f(as._2()));
+      if (predicate.f(acc2)) {
+        return P.p(some(mk.one(as._1())), as._2(), some(mk.two(as._3(), as._4())));
+      } else if (predicate.f(m.sum(acc2, measure.f(as._3())))) {
+        return P.p(some(mk.two(as._1(), as._2())), as._3(), some(mk.one(as._4())));
+      } else {
+        return P.p(some(mk.three(as._1(), as._2(), as._3())), as._4(), none());
+      }
+    }
+  }
+
+  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
+    final F<A, V> m = measured().measure();
+    final int s1 = o.f(m.f(as._1()));
+    if (i < s1) {
+      return P.p(i, as._1());
+    } else {
+      final int s2 = s1 + o.f(m.f(as._2()));
+      if (i < s2) {
+        return P.p(i - s1, as._2());
+      } else {
+        final int s3 = s2 + o.f(m.f(as._3()));
+        if (i < s3) {
+          return P.p(i - s2, as._3());
+        } else {
+          return P.p(i - s3, as._4());
+        }
+      }
+    }
   }
 }

--- a/core/src/main/java/fj/data/fingertrees/Node.java
+++ b/core/src/main/java/fj/data/fingertrees/Node.java
@@ -3,6 +3,9 @@ package fj.data.fingertrees;
 import fj.F;
 import fj.F2;
 import fj.P2;
+import fj.P3;
+import fj.data.Option;
+
 import static fj.Function.curry;
 
 /**
@@ -62,6 +65,8 @@ public abstract class Node<V, A> {
   Measured<V, A> measured() {
     return m;
   }
+
+  abstract P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc);
 
   public abstract P2<Integer, A> lookup(final F<V, Integer> o, final int i);
 

--- a/core/src/main/java/fj/data/fingertrees/Node2.java
+++ b/core/src/main/java/fj/data/fingertrees/Node2.java
@@ -1,8 +1,15 @@
 package fj.data.fingertrees;
 
+import fj.P;
+import fj.P3;
+import fj.data.Option;
 import fj.data.vector.V2;
 import fj.F;
 import fj.P2;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
  * A two-element inner tree node.
@@ -27,9 +34,24 @@ public final class Node2<V, A> extends Node<V, A> {
     return new Two<V, A>(measured(), as);
   }
 
-  @SuppressWarnings({"ReturnOfNull"})
+  P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final MakeTree<V, A> mk = mkTree(m);
+    if (predicate.f(m.sum(acc, m.measure().f(as._1())))) {
+      return P.p(none(), as._1(), some(mk.one(as._2())));
+    } else {
+      return P.p(some(mk.one(as._1())), as._2(), none());
+    }
+  }
+
   @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
-    return null; // TODO
+    final F<A, V> m = measured().measure();
+    final int s1 = o.f(m.f(as._1()));
+    if (i < s1) {
+      return P.p(i, as._1());
+    } else {
+      return P.p(i - s1, as._2());
+    }
   }
 
   public <B> B match(final F<Node2<V, A>, B> n2, final F<Node3<V, A>, B> n3) {

--- a/core/src/main/java/fj/data/fingertrees/Node3.java
+++ b/core/src/main/java/fj/data/fingertrees/Node3.java
@@ -1,8 +1,15 @@
 package fj.data.fingertrees;
 
+import fj.P;
+import fj.P3;
+import fj.data.Option;
 import fj.data.vector.V3;
 import fj.F;
 import fj.P2;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
  * A three-element inner tree node.
@@ -31,9 +38,32 @@ public final class Node3<V, A> extends Node<V, A> {
     return new Three<V, A>(measured(), as);
   }
 
-  @SuppressWarnings({"ReturnOfNull"})
-  public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
-    return null;  //TODO
+  P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final MakeTree<V, A> mk = mkTree(m);
+    final V acc1 = m.sum(acc, m.measure().f(as._1()));
+    if (predicate.f(acc1)) {
+      return P.p(none(), as._1(), some(mk.two(as._2(), as._3())));
+    } else if (predicate.f(m.sum(acc1, m.measure().f(as._2())))) {
+      return P.p(some(mk.one(as._1())), as._2(), some(mk.one(as._3())));
+    } else {
+      return P.p(some(mk.two(as._1(), as._2())), as._3(), none());
+    }
+  }
+
+  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
+    final F<A, V> m = measured().measure();
+    final int s1 = o.f(m.f(as._1()));
+    if (i < s1) {
+      return P.p(i, as._1());
+    } else {
+      final int s2 = s1 + o.f(m.f(as._2()));
+      if (i < s2) {
+        return P.p(i - s1, as._2());
+      } else {
+        return P.p(i - s2, as._3());
+      }
+    }
   }
 
   public V3<A> toVector() {

--- a/core/src/main/java/fj/data/fingertrees/One.java
+++ b/core/src/main/java/fj/data/fingertrees/One.java
@@ -1,6 +1,12 @@
 package fj.data.fingertrees;
 
 import fj.F;
+import fj.P;
+import fj.P2;
+import fj.P3;
+import fj.data.Option;
+
+import static fj.data.Option.none;
 
 /**
  * A single-element prefix or suffix of a finger tree.
@@ -34,5 +40,13 @@ public final class One<V, A> extends Digit<V, A> {
    */
   public A value() {
     return a;
+  }
+
+  @Override P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    return P.p(none(), a, none());
+  }
+
+  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
+    return P.p(i, a);
   }
 }

--- a/core/src/main/java/fj/data/fingertrees/Single.java
+++ b/core/src/main/java/fj/data/fingertrees/Single.java
@@ -1,7 +1,10 @@
 package fj.data.fingertrees;
 
 import fj.F;
+import fj.P;
 import fj.P2;
+import fj.P3;
+
 import static fj.P.p;
 
 /**
@@ -64,13 +67,24 @@ public final class Single<V, A> extends FingerTree<V, A> {
     return mk.deep(mk.one(a), new Empty<V, Node<V, A>>(measured().nodeMeasured()), mk.one(b));
   }
 
+  @Override public A head() { return a; }
+
+  @Override public A last() { return a; }
+
+  @Override public FingerTree<V, A> tail() { return new Empty<>(measured()); }
+
+  @Override public FingerTree<V, A> init() { return new Empty<>(measured()); }
+
   @Override public FingerTree<V, A> append(final FingerTree<V, A> t) {
     return t.cons(a);
   }
 
-  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) {
-    return p(i, a);
+  @Override P3<FingerTree<V, A>, A, FingerTree<V, A>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Empty<V, A> empty = new Empty<>(measured());
+    return P.p(empty, a, empty);
   }
+
+  @Override public P2<Integer, A> lookup(final F<V, Integer> o, final int i) { return p(i, a); }
 
   /**
    * Returns the single element of this tree.

--- a/core/src/main/java/fj/data/fingertrees/Three.java
+++ b/core/src/main/java/fj/data/fingertrees/Three.java
@@ -1,7 +1,15 @@
 package fj.data.fingertrees;
 
+import fj.P;
+import fj.P2;
+import fj.P3;
+import fj.data.Option;
 import fj.data.vector.V3;
 import fj.F;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
  * A three-element prefix or suffix of a finger tree.
@@ -35,5 +43,34 @@ public final class Three<V, A> extends Digit<V, A> {
    */
   public V3<A> values() {
     return as;
+  }
+
+  @Override P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final MakeTree<V, A> mk = mkTree(m);
+    final F<A, V> measure = m.measure();
+    final V acc1 = m.sum(acc, measure.f(as._1()));
+    if (predicate.f(acc1)) {
+      return P.p(none(), as._1(), some(mk.two(as._2(), as._3())));
+    } else if (predicate.f(m.sum(acc1, measure.f(as._2())))) {
+      return P.p(some(mk.one(as._1())), as._2(), some(mk.one(as._3())));
+    } else {
+      return P.p(some(mk.two(as._1(), as._2())), as._3(), none());
+    }
+  }
+
+  @Override public P2<Integer, A> lookup(F<V, Integer> o, int i) {
+    final F<A, V> m = measured().measure();
+    final int s1 = o.f(m.f(as._1()));
+    if (i < s1) {
+      return P.p(i, as._1());
+    } else {
+      final int s2 = s1 + o.f(m.f(as._2()));
+      if (i < s2) {
+        return P.p(i - s1, as._2());
+      } else {
+        return P.p(i - s2, as._3());
+      }
+    }
   }
 }

--- a/core/src/main/java/fj/data/fingertrees/Two.java
+++ b/core/src/main/java/fj/data/fingertrees/Two.java
@@ -1,7 +1,15 @@
 package fj.data.fingertrees;
 
+import fj.P;
+import fj.P2;
+import fj.P3;
+import fj.data.Option;
 import fj.data.vector.V2;
 import fj.F;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.data.fingertrees.FingerTree.mkTree;
 
 /**
  * A two-element prefix or suffix of a finger tree.
@@ -35,5 +43,25 @@ public final class Two<V, A> extends Digit<V, A> {
    */
   public V2<A> values() {
     return as;
+  }
+
+  @Override P3<Option<Digit<V, A>>, A, Option<Digit<V, A>>> split1(final F<V, Boolean> predicate, final V acc) {
+    final Measured<V, A> m = measured();
+    final MakeTree<V, A> mk = mkTree(m);
+    if (predicate.f(m.sum(acc, m.measure().f(as._1())))) {
+      return P.p(none(), as._1(), some(mk.one(as._2())));
+    } else {
+      return P.p(some(mk.one(as._1())), as._2(), none());
+    }
+  }
+
+  @Override public P2<Integer, A> lookup(F<V, Integer> o, int i) {
+    final F<A, V> m = measured().measure();
+    final int s1 = o.f(m.f(as._1()));
+    if (i < s1) {
+      return P.p(i, as._1());
+    } else {
+      return P.p(i - s1, as._2());
+    }
   }
 }

--- a/core/src/test/java/fj/data/ListTest.java
+++ b/core/src/test/java/fj/data/ListTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -39,4 +40,17 @@ public class ListTest {
 
     }
 
+    @Test
+    public void convertToString() {
+        final int n = 10000;
+        final StringBuilder expected = new StringBuilder("List(");
+        for (int i = 0; i < n; i++) {
+            expected.append(i);
+            if (i < n - 1) {
+                expected.append(',');
+            }
+        }
+        expected.append(')');
+        assertEquals(expected.toString(), List.range(0, n).toString());
+    }
 }

--- a/core/src/test/java/fj/data/SeqTest.java
+++ b/core/src/test/java/fj/data/SeqTest.java
@@ -2,6 +2,7 @@ package fj.data;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -20,4 +21,17 @@ public class SeqTest {
 
     }
 
+    @Test
+    public void convertToString() {
+        final int n = 10000;
+        final StringBuilder expected = new StringBuilder("Seq(");
+        for (int i = 0; i < n; i++) {
+            expected.append(i);
+            if (i < n - 1) {
+                expected.append(',');
+            }
+        }
+        expected.append(')');
+        assertEquals(expected.toString(), Seq.seq(Array.range(0, 10000).array()).toString());
+    }
 }

--- a/core/src/test/java/fj/data/StreamTest.java
+++ b/core/src/test/java/fj/data/StreamTest.java
@@ -1,0 +1,17 @@
+package fj.data;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Zheka Kozlov on 27.05.2015.
+ */
+public class StreamTest {
+
+  @Test
+  public void infiniteStream() {
+    Stream<Integer> s = Stream.forever(Enumerator.intEnumerator, 0).bind(Stream::single);
+    assertEquals(List.range(0, 5), s.take(5).toList());
+  }
+}


### PR DESCRIPTION
There was some missing base functionality in FingerTree and Seq. I've implemented the following methods:
* FingerTree: head, last, tail, init, split, split1, lookup (lookup returned null for Deep)
* Seq: head, last, tail, init, split, update, toJavaList

Also, Seq is now Iterable and can be used in foreach loops.