### PR TITLE
Fixed bug in FingerTree.append(). Added PropertyTestRunner

### DIFF
--- a/core/src/main/java/fj/Hash.java
+++ b/core/src/main/java/fj/Hash.java
@@ -11,6 +11,9 @@ import fj.data.vector.V6;
 import fj.data.vector.V7;
 import fj.data.vector.V8;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 /**
  * Produces a hash code for an object which should attempt uniqueness.
  *
@@ -101,6 +104,16 @@ public final class Hash<A> {
    * A hash instance for the <code>short</code> type.
    */
   public static final Hash<Short> shortHash = anyHash();
+
+  /**
+   * A hash instance for the <code>BigInteger</code> type.
+   */
+  public static final Hash<BigInteger> bigintHash = anyHash();
+
+  /**
+   * A hash instance for the <code>BigDecimal</code> type.
+   */
+  public static final Hash<BigDecimal> bigdecimalHash = anyHash();
 
   /**
    * A hash instance for the <code>String</code> type.

--- a/core/src/main/java/fj/data/NonEmptyList.java
+++ b/core/src/main/java/fj/data/NonEmptyList.java
@@ -55,6 +55,12 @@ public final class NonEmptyList<A> implements Iterable<A> {
     return nel(a, tail.cons(head));
   }
 
+  /**
+   * Appends (snoc) the given element to this non empty list to produce a new non empty list. O(n).
+   *
+   * @param a The element to append to this non empty list.
+   * @return A new non empty list with the given element appended.
+   */
   public NonEmptyList<A> snoc(final A a) {
     return nel(head, tail.snoc(a));
   }
@@ -148,41 +154,95 @@ public final class NonEmptyList<A> implements Iterable<A> {
     return tails().map(f);
   }
 
+  /**
+   * Intersperses the given argument between each element of this non empty list.
+   *
+   * @param a The separator to intersperse in this non empty list.
+   * @return A non empty list with the given separator interspersed.
+   */
   public NonEmptyList<A> intersperse(final A a) {
     final List<A> list = toList().intersperse(a);
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Reverse this non empty list in constant stack space.
+   *
+   * @return A new non empty list with the elements in reverse order.
+   */
   public NonEmptyList<A> reverse() {
     final List<A> list = toList().reverse();
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Sorts this non empty list using the given order over elements using a <em>merge sort</em> algorithm.
+   *
+   * @param o The order over the elements of this non empty list.
+   * @return A sorted non empty list according to the given order.
+   */
   public NonEmptyList<A> sort(final Ord<A> o) {
     final List<A> list = toList().sort(o);
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Zips this non empty list with the given non empty list to produce a list of pairs. If this list and the given list
+   * have different lengths, then the longer list is normalised so this function never fails.
+   *
+   * @param bs The non empty list to zip this non empty list with.
+   * @return A new non empty list with a length the same as the shortest of this list and the given list.
+   */
   public <B> NonEmptyList<P2<A, B>> zip(final NonEmptyList<B> bs) {
     final List<P2<A, B>> list = toList().zip(bs.toList());
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Zips this non empty list with the index of its element as a pair.
+   *
+   * @return A new non empty list with the same length as this list.
+   */
   public NonEmptyList<P2<A, Integer>> zipIndex() {
     final List<P2<A, Integer>> list = toList().zipIndex();
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Zips this non empty list with the given non empty list using the given function to produce a new list. If this list
+   * and the given list have different lengths, then the longer list is normalised so this function
+   * never fails.
+   *
+   * @param bs The non empty list to zip this non empty list with.
+   * @param f  The function to zip this non empty list and the given non empty list with.
+   * @return A new non empty list with a length the same as the shortest of this list and the given list.
+   */
   public <B, C> NonEmptyList<C> zipWith(final List<B> bs, final F<A, F<B, C>> f) {
     final List<C> list = toList().zipWith(bs, f);
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Zips this non empty list with the given non empty list using the given function to produce a new list. If this list
+   * and the given list have different lengths, then the longer list is normalised so this function
+   * never fails.
+   *
+   * @param bs The non empty list to zip this non empty list with.
+   * @param f  The function to zip this non empty list and the given non empty list with.
+   * @return A new non empty list with a length the same as the shortest of this list and the given list.
+   */
   public <B, C> NonEmptyList<C> zipWith(final List<B> bs, final F2<A, B, C> f) {
     final List<C> list = toList().zipWith(bs, f);
     return nel(list.head(), list.tail());
   }
 
+  /**
+   * Transforms a non empty list of pairs into a non empty list of first components and
+   * a non empty list of second components.
+   *
+   * @param xs The non empty list of pairs to transform.
+   * @return A non empty list of first components and a non empty list of second components.
+   */
   public static <A, B> P2<NonEmptyList<A>, NonEmptyList<B>> unzip(final NonEmptyList<P2<A, B>> xs) {
     final P2<List<A>, List<B>> p = List.unzip(xs.toList());
     return P.p(nel(p._1().head(), p._1().tail()), nel(p._2().head(), p._2().tail()));
@@ -258,6 +318,12 @@ public final class NonEmptyList<A> implements Iterable<A> {
            some(nel(as.head(), as.tail()));
   }
 
+  /**
+   * Concatenate (join) a non empty list of non empty lists.
+   *
+   * @param o The non empty list of non empty lists to join.
+   * @return A new non empty list that is the concatenation of the given lists.
+   */
   public static <A> NonEmptyList<A> join(final NonEmptyList<NonEmptyList<A>> o) { return o.bind(identity()); }
 
   /**

--- a/core/src/main/java/fj/data/NonEmptyList.java
+++ b/core/src/main/java/fj/data/NonEmptyList.java
@@ -1,14 +1,16 @@
 package fj.data;
 
+import fj.Equal;
 import fj.F;
 import fj.F1Functions;
+import fj.Show;
 import fj.function.Effect1;
-
-import static fj.data.Option.some;
-import static fj.data.Option.somes;
 
 import java.util.Collection;
 import java.util.Iterator;
+
+import static fj.data.Option.some;
+import static fj.data.Option.somes;
 
 /**
  * Provides an in-memory, immutable, singly linked list with total <code>head</code> and <code>tail</code>.
@@ -26,17 +28,19 @@ public final class NonEmptyList<A> implements Iterable<A> {
     return toCollection().iterator();
   }
 
+  private final A head;
+
+  private final List<A> tail;
+
   /**
    * The first element of this linked list.
    */
-  @SuppressWarnings({"PublicField", "ClassEscapesDefinedScope"})
-  public final A head;
+  public A head() { return head; }
 
   /**
    * This list without the first element.
    */
-  @SuppressWarnings({"PublicField"})
-  public final List<A> tail;
+  public List<A> tail() { return tail; }
 
   private NonEmptyList(final A head, final List<A> tail) {
     this.head = head;
@@ -52,6 +56,13 @@ public final class NonEmptyList<A> implements Iterable<A> {
   public NonEmptyList<A> cons(final A a) {
     return nel(a, tail.cons(head));
   }
+
+  /**
+   * The length of this list.
+   *
+   * @return The length of this list.
+   */
+  public int length() { return 1 + tail.length(); }
 
   /**
    * Appends the given list to this list.
@@ -203,4 +214,17 @@ public final class NonEmptyList<A> implements Iterable<A> {
            Option.<NonEmptyList<A>>none() :
            some(nel(as.head(), as.tail()));
   }
+
+  /**
+   * Perform an equality test on this list which delegates to the .equals() method of the member instances.
+   * This is implemented with Equal.nonEmptyListEqual using the anyEqual rule.
+   *
+   * @param obj the other object to check for equality against.
+   * @return true if this list is equal to the provided argument
+   */
+  @Override public boolean equals( final Object obj ) {
+    return Equal.equals0(NonEmptyList.class, this, obj, () -> Equal.nonEmptyListEqual(Equal.<A>anyEqual()));
+  }
+
+  @Override public String toString() { return Show.nonEmptyListShow(Show.<A>anyShow()).showS(this); }
 }

--- a/core/src/main/java/fj/data/NonEmptyList.java
+++ b/core/src/main/java/fj/data/NonEmptyList.java
@@ -6,6 +6,7 @@ import fj.function.Effect1;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static fj.Function.identity;
 import static fj.data.Option.some;
 import static fj.data.Option.somes;
 
@@ -52,6 +53,10 @@ public final class NonEmptyList<A> implements Iterable<A> {
    */
   public NonEmptyList<A> cons(final A a) {
     return nel(a, tail.cons(head));
+  }
+
+  public NonEmptyList<A> snoc(final A a) {
+    return nel(head, tail.snoc(a));
   }
 
   /**
@@ -143,6 +148,46 @@ public final class NonEmptyList<A> implements Iterable<A> {
     return tails().map(f);
   }
 
+  public NonEmptyList<A> intersperse(final A a) {
+    final List<A> list = toList().intersperse(a);
+    return nel(list.head(), list.tail());
+  }
+
+  public NonEmptyList<A> reverse() {
+    final List<A> list = toList().reverse();
+    return nel(list.head(), list.tail());
+  }
+
+  public NonEmptyList<A> sort(final Ord<A> o) {
+    final List<A> list = toList().sort(o);
+    return nel(list.head(), list.tail());
+  }
+
+  public <B> NonEmptyList<P2<A, B>> zip(final NonEmptyList<B> bs) {
+    final List<P2<A, B>> list = toList().zip(bs.toList());
+    return nel(list.head(), list.tail());
+  }
+
+  public NonEmptyList<P2<A, Integer>> zipIndex() {
+    final List<P2<A, Integer>> list = toList().zipIndex();
+    return nel(list.head(), list.tail());
+  }
+
+  public <B, C> NonEmptyList<C> zipWith(final List<B> bs, final F<A, F<B, C>> f) {
+    final List<C> list = toList().zipWith(bs, f);
+    return nel(list.head(), list.tail());
+  }
+
+  public <B, C> NonEmptyList<C> zipWith(final List<B> bs, final F2<A, B, C> f) {
+    final List<C> list = toList().zipWith(bs, f);
+    return nel(list.head(), list.tail());
+  }
+
+  public static <A, B> P2<NonEmptyList<A>, NonEmptyList<B>> unzip(final NonEmptyList<P2<A, B>> xs) {
+    final P2<List<A>, List<B>> p = List.unzip(xs.toList());
+    return P.p(nel(p._1().head(), p._1().tail()), nel(p._2().head(), p._2().tail()));
+  }
+
   /**
    * Returns a <code>List</code> projection of this list.
    *
@@ -182,13 +227,14 @@ public final class NonEmptyList<A> implements Iterable<A> {
   }
 
   /**
-   * Return a non-empty list with the given value.
+   * Constructs a non empty list from the given elements.
    *
-   * @param head The value in the non-empty list.
-   * @return A non-empty list with the given value.
+   * @param head The first in the non-empty list.
+   * @param tail The elements to construct a list's tail with.
+   * @return A non-empty list with the given elements.
    */
-  public static <A> NonEmptyList<A> nel(final A head) {
-    return nel(head, List.<A>nil());
+  public static <A> NonEmptyList<A> nel(final A head, final A... tail) {
+    return nel(head, List.list(tail));
   }
 
   /**
@@ -211,6 +257,8 @@ public final class NonEmptyList<A> implements Iterable<A> {
            Option.<NonEmptyList<A>>none() :
            some(nel(as.head(), as.tail()));
   }
+
+  public static <A> NonEmptyList<A> join(final NonEmptyList<NonEmptyList<A>> o) { return o.bind(identity()); }
 
   /**
    * Perform an equality test on this list which delegates to the .equals() method of the member instances.

--- a/core/src/main/java/fj/data/NonEmptyList.java
+++ b/core/src/main/java/fj/data/NonEmptyList.java
@@ -1,9 +1,6 @@
 package fj.data;
 
-import fj.Equal;
-import fj.F;
-import fj.F1Functions;
-import fj.Show;
+import fj.*;
 import fj.function.Effect1;
 
 import java.util.Collection;
@@ -224,6 +221,10 @@ public final class NonEmptyList<A> implements Iterable<A> {
    */
   @Override public boolean equals( final Object obj ) {
     return Equal.equals0(NonEmptyList.class, this, obj, () -> Equal.nonEmptyListEqual(Equal.<A>anyEqual()));
+  }
+
+  @Override public int hashCode() {
+    return Hash.nonEmptyListHash(Hash.<A>anyHash()).hash(this);
   }
 
   @Override public String toString() { return Show.nonEmptyListShow(Show.<A>anyShow()).showS(this); }

--- a/core/src/main/java/fj/data/fingertrees/Deep.java
+++ b/core/src/main/java/fj/data/fingertrees/Deep.java
@@ -155,7 +155,7 @@ public final class Deep<V, A> extends FingerTree<V, A> {
   @Override public FingerTree<V, A> append(final FingerTree<V, A> t) {
     final Measured<V, A> m = measured();
     return t.match(
-      constant(t),
+      constant(this),
       single -> snoc(single.value()),
       deep -> new Deep<>(m, m.sum(measure(), deep.measure()), prefix,
         addDigits0(m, middle, suffix, deep.prefix, deep.middle), deep.suffix));

--- a/core/src/main/java/fj/test/Arbitrary.java
+++ b/core/src/main/java/fj/test/Arbitrary.java
@@ -762,6 +762,16 @@ public final class Arbitrary<A> {
   }
 
   /**
+   * Returns an arbitrary implementation for sequences.
+   *
+   * @param aa An arbitrary implementation for the type over which the sequence is defined.
+   * @return An arbitrary implementation for sequences.
+   */
+  public static <A> Arbitrary<Seq<A>> arbSeq(final Arbitrary<A> aa) {
+    return arbitrary(arbArray(aa).gen.map(array -> Seq.seq((A[]) array.array())));
+  }
+
+  /**
    * Returns an arbitrary implementation for throwables.
    *
    * @param as An arbitrary used for the throwable message.

--- a/core/src/main/java/fj/test/Arbitrary.java
+++ b/core/src/main/java/fj/test/Arbitrary.java
@@ -733,6 +733,10 @@ public final class Arbitrary<A> {
     return arbitrary(listOf(aa.gen));
   }
 
+  public static <A> Arbitrary<NonEmptyList<A>> arbNonEmptyList(final Arbitrary<A> aa) {
+    return arbitrary(Gen.listOf1(aa.gen).map(list -> NonEmptyList.fromList(list).some()));
+  }
+
   /**
    * Returns an arbitrary implementation for streams.
    *

--- a/core/src/main/java/fj/test/Gen.java
+++ b/core/src/main/java/fj/test/Gen.java
@@ -554,15 +554,7 @@ public final class Gen<A> {
    * @return A generator of lists whose values come from the given generator.
    */
   public static <A> Gen<List<A>> listOf(final Gen<A> g, final int x) {
-    return sized(new F<Integer, Gen<List<A>>>() {
-      public Gen<List<A>> f(final Integer size) {
-        return choose(x, size).bind(new F<Integer, Gen<List<A>>>() {
-          public Gen<List<A>> f(final Integer n) {
-            return sequenceN(n, g);
-          }
-        });
-      }
-    });
+    return sized(size -> choose(x, max(x, size)).bind(n -> sequenceN(n, g)));
   }
 
   /**
@@ -576,7 +568,7 @@ public final class Gen<A> {
   }
 
   /**
-   * Returns a generator of lists whose values come from the given generator.
+   * Returns a generator of non empty lists whose values come from the given generator.
    *
    * @param g The generator to produce values from for the returned generator.
    * @return A generator of lists whose values come from the given generator.

--- a/core/src/main/java/fj/test/Rand.java
+++ b/core/src/main/java/fj/test/Rand.java
@@ -124,38 +124,15 @@ public final class Rand {
   /**
    * A standard random generator that uses {@link Random}.
    */
-  public static final Rand standard = new Rand(new F<Option<Long>, F<Integer, F<Integer, Integer>>>() {
-    public F<Integer, F<Integer, Integer>> f(final Option<Long> seed) {
-      return new F<Integer, F<Integer, Integer>>() {
-        public F<Integer, Integer> f(final Integer from) {
-          return new F<Integer, Integer>() {
-            public Integer f(final Integer to) {
-              if(from == to){
-                return from;
-              }else{
-                final int f = min(from, to);
-                final int t = max(from, to);
-                final int x = Math.abs(t - f);
-                return f + seed.map(fr).orSome(new Random()).nextInt(x == Integer.MIN_VALUE ? Integer.MAX_VALUE : x);
-              }
-            }
-          };
-        }
-      };
-    }
-  }, new F<Option<Long>, F<Double, F<Double, Double>>>() {
-    public F<Double, F<Double, Double>> f(final Option<Long> seed) {
-      return new F<Double, F<Double, Double>>() {
-        public F<Double, Double> f(final Double from) {
-          return new F<Double, Double>() {
-            public Double f(final Double to) {
-              final double f = min(from, to);
-              final double t = max(from, to);
-              return seed.map(fr).orSome(new Random()).nextDouble() * (t - f) + f;
-            }
-          };
-        }
-      };
-    }
+  public static final Rand standard = new Rand(seed -> from -> to -> {
+    final int min = min(from, to);
+    final int max = max(from, to);
+    final Random random = seed.map(fr).orSome(new Random());
+    return (int) ((random.nextLong() & Long.MAX_VALUE) % (1L + max - min)) + min;
+  }, seed -> from -> to -> {
+    final double min = min(from, to);
+    final double max = max(from, to);
+    final Random random = seed.map(fr).orSome(new Random());
+    return random.nextDouble() * (max - min) + min;
   });
 }

--- a/core/src/test/java/fj/data/properties/NonEmptyListProperties.java
+++ b/core/src/test/java/fj/data/properties/NonEmptyListProperties.java
@@ -1,0 +1,48 @@
+package fj.data.properties;
+
+import fj.runner.PropertyTestRunner;
+import fj.test.Property;
+import org.junit.runner.RunWith;
+
+import static fj.Function.identity;
+import static fj.data.NonEmptyList.nel;
+import static fj.test.Arbitrary.arbInteger;
+import static fj.test.Arbitrary.arbNonEmptyList;
+import static fj.test.Property.prop;
+import static fj.test.Property.property;
+
+/**
+ * Created by Zheka Kozlov on 02.06.2015.
+ */
+@RunWith(PropertyTestRunner.class)
+public class NonEmptyListProperties {
+
+  public Property consHead() {
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(list.cons(n).head().equals(n)));
+  }
+
+  public Property consLength() {
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(list.cons(n).length() == list.length() + 1));
+  }
+
+  public Property positiveLength() {
+    return property(arbNonEmptyList(arbInteger), list -> prop(list.length() > 0));
+  }
+
+  public Property appendLength() {
+    return property(arbNonEmptyList(arbInteger), arbNonEmptyList(arbInteger), (list1, list2) ->
+      prop(list1.append(list2).length() == list1.length() + list2.length()));
+  }
+
+  public Property appendSingle() {
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(nel(n).append(list).equals(list.cons(n))));
+  }
+
+  public Property tailLength() {
+    return property(arbNonEmptyList(arbInteger), list -> prop(list.length() == 1 + list.tail().length()));
+  }
+
+  public Property mapId() {
+    return property(arbNonEmptyList(arbInteger), list -> prop(list.map(identity()).equals(list)));
+  }
+}

--- a/core/src/test/java/fj/data/properties/NonEmptyListProperties.java
+++ b/core/src/test/java/fj/data/properties/NonEmptyListProperties.java
@@ -1,15 +1,28 @@
 package fj.data.properties;
 
+import fj.Equal;
+import fj.Ord;
+import fj.P2;
+import fj.data.List;
+import fj.data.NonEmptyList;
 import fj.runner.PropertyTestRunner;
 import fj.test.Property;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static fj.Equal.intEqual;
+import static fj.Equal.listEqual;
+import static fj.Equal.nonEmptyListEqual;
 import static fj.Function.identity;
 import static fj.data.NonEmptyList.nel;
+import static fj.data.NonEmptyList.unzip;
 import static fj.test.Arbitrary.arbInteger;
 import static fj.test.Arbitrary.arbNonEmptyList;
 import static fj.test.Property.prop;
 import static fj.test.Property.property;
+import static java.lang.Math.min;
 
 /**
  * Created by Zheka Kozlov on 02.06.2015.
@@ -17,8 +30,11 @@ import static fj.test.Property.property;
 @RunWith(PropertyTestRunner.class)
 public class NonEmptyListProperties {
 
+  private static final Equal<NonEmptyList<Integer>> eq = nonEmptyListEqual(intEqual);
+  private static final Equal<List<Integer>> listEq = listEqual(intEqual);
+
   public Property consHead() {
-    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(list.cons(n).head().equals(n)));
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(intEqual.eq(list.cons(n).head(), n)));
   }
 
   public Property consLength() {
@@ -35,7 +51,7 @@ public class NonEmptyListProperties {
   }
 
   public Property appendSingle() {
-    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(nel(n).append(list).equals(list.cons(n))));
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) -> prop(eq.eq(nel(n).append(list), list.cons(n))));
   }
 
   public Property tailLength() {
@@ -43,6 +59,48 @@ public class NonEmptyListProperties {
   }
 
   public Property mapId() {
-    return property(arbNonEmptyList(arbInteger), list -> prop(list.map(identity()).equals(list)));
+    return property(arbNonEmptyList(arbInteger), list -> prop(eq.eq(list.map(identity()), list)));
+  }
+
+  public Property reverse() {
+    return property(arbNonEmptyList(arbInteger), list ->
+      prop(listEq.eq(list.reverse().toList(), list.tail().reverse().snoc(list.head()))));
+  }
+
+  public Property doubleReverse() {
+    return property(arbNonEmptyList(arbInteger), list -> prop(eq.eq(list.reverse().reverse(), list)));
+  }
+
+  public Property sort() {
+    return property(arbNonEmptyList(arbInteger), list -> {
+      java.util.List<Integer> javaList = list.sort(Ord.intOrd).toList().toJavaList();
+      java.util.List<Integer> copy = new ArrayList<>(javaList);
+      Collections.sort(copy);
+      return prop(javaList.equals(copy));
+    });
+  }
+
+  public Property intersperseLength() {
+    return property(arbNonEmptyList(arbInteger), arbInteger, (list, n) ->
+      prop(list.intersperse(n).length() == 2 * list.length() - 1));
+  }
+
+  public Property zip() {
+    return property(arbNonEmptyList(arbInteger), arbNonEmptyList(arbInteger), (list1, list2) -> {
+      final int size = min(list1.length(), list2.length());
+      final NonEmptyList<P2<Integer, Integer>> zipped = list1.zip(list2);
+      return prop(listEq.eq(zipped.map(P2::_1).toList(), list1.toList().take(size)))
+        .and(prop(listEq.eq(zipped.map(P2::_2).toList(), list2.toList().take(size))));
+    });
+  }
+
+  public Property zipUnzip() {
+    return property(arbNonEmptyList(arbInteger), arbNonEmptyList(arbInteger), (list1, list2) -> {
+      final P2<NonEmptyList<Integer>, NonEmptyList<Integer>> unzipped = unzip(list1.zip(list2));
+      final int size = min(list1.length(), list2.length());
+      return prop(listEq.eq(unzipped._1().toList(), list1.toList().take(size)))
+        .and(prop(listEq.eq(unzipped._2().toList(), list2.toList().take(size))));
+    });
+
   }
 }

--- a/core/src/test/java/fj/data/properties/SeqProperties.java
+++ b/core/src/test/java/fj/data/properties/SeqProperties.java
@@ -1,7 +1,6 @@
 package fj.data.properties;
 
 
-import fj.Function;
 import fj.P;
 import fj.P2;
 import fj.data.Option;
@@ -10,10 +9,7 @@ import fj.runner.PropertyTestRunner;
 import fj.test.Arbitrary;
 import fj.test.Gen;
 import fj.test.Property;
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
 
 import static fj.Function.identity;
 import static fj.data.Option.none;
@@ -81,12 +77,12 @@ public class SeqProperties {
 
   public Property tailLength() {
     return property(arbSeq(arbInteger), seq ->
-      Property.implies(!seq.isEmpty(), P.lazy(() -> prop(seq.length() == 1 + seq.tail().length()))));
+      implies(!seq.isEmpty(), () -> prop(seq.length() == 1 + seq.tail().length())));
   }
 
   public Property initLength() {
     return property(arbSeq(arbInteger), seq ->
-      Property.implies(!seq.isEmpty(), P.lazy(() -> prop(seq.length() == seq.init().length() + 1))));
+      implies(!seq.isEmpty(), () -> prop(seq.length() == seq.init().length() + 1)));
   }
 
   public Property mapId() {
@@ -103,11 +99,11 @@ public class SeqProperties {
     });
 
     return property(Arbitrary.arbitrary(gen), arbInteger, (pair, n) ->
-      implies(pair._2().isSome(), P.lazy(() -> {
+      implies(pair._2().isSome(), () -> {
         final Seq<Integer> seq = pair._1();
         final int index = pair._2().some();
         return prop(seq.update(index, n).index(index).equals(n));
-      })));
+      }));
   }
 
   public Property foldLeft() {

--- a/core/src/test/java/fj/data/properties/SeqProperties.java
+++ b/core/src/test/java/fj/data/properties/SeqProperties.java
@@ -1,0 +1,122 @@
+package fj.data.properties;
+
+
+import fj.Function;
+import fj.P;
+import fj.P2;
+import fj.data.Option;
+import fj.data.Seq;
+import fj.runner.PropertyTestRunner;
+import fj.test.Arbitrary;
+import fj.test.Gen;
+import fj.test.Property;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+import static fj.Function.identity;
+import static fj.data.Option.none;
+import static fj.data.Option.some;
+import static fj.test.Arbitrary.arbInteger;
+import static fj.test.Arbitrary.arbSeq;
+import static fj.test.Property.implies;
+import static fj.test.Property.prop;
+import static fj.test.Property.property;
+
+/**
+ * Created by Zheka Kozlov on 01.06.2015.
+ */
+@RunWith(PropertyTestRunner.class)
+public class SeqProperties {
+
+  public Property consHead() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(seq.cons(n).head().equals(n)));
+  }
+
+  public Property consLength() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(seq.cons(n).length() == seq.length() + 1));
+  }
+
+  public Property snocLast() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(seq.snoc(n).last().equals(n)));
+  }
+
+  public Property snocLength() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(seq.snoc(n).length() == seq.length() + 1));
+  }
+
+  public Property appendEmptyLeft() {
+    return property(arbSeq(arbInteger), seq -> prop(Seq.<Integer>empty().append(seq).equals(seq)));
+  }
+
+  public Property appendEmptyRight() {
+    return property(arbSeq(arbInteger), seq -> prop(seq.append(Seq.empty()).equals(seq)));
+  }
+
+  public Property appendLength() {
+    return property(arbSeq(arbInteger), arbSeq(arbInteger), (seq1, seq2) ->
+      prop(seq1.append(seq2).length() == seq1.length() + seq2.length()));
+  }
+
+  public Property consNotEmpty() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(!seq.cons(n).isEmpty()));
+  }
+
+  public Property snocNotEmpty() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(!seq.snoc(n).isEmpty()));
+  }
+
+  public Property appendSingleLeft() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(Seq.single(n).append(seq).equals(seq.cons(n))));
+  }
+
+  public Property appendSingleRight() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, n) -> prop(seq.append(Seq.single(n)).equals(seq.snoc(n))));
+  }
+
+  public Property splitLength() {
+    return property(arbSeq(arbInteger), arbInteger, (seq, i) -> prop(seq.length() == seq.split(i)._1().length() + seq.split(i)._2().length()));
+  }
+
+  public Property tailLength() {
+    return property(arbSeq(arbInteger), seq ->
+      Property.implies(!seq.isEmpty(), P.lazy(() -> prop(seq.length() == 1 + seq.tail().length()))));
+  }
+
+  public Property initLength() {
+    return property(arbSeq(arbInteger), seq ->
+      Property.implies(!seq.isEmpty(), P.lazy(() -> prop(seq.length() == seq.init().length() + 1))));
+  }
+
+  public Property mapId() {
+    return property(arbSeq(arbInteger), seq -> prop(seq.map(identity()).equals(seq)));
+  }
+
+  public Property updateAndIndex() {
+    final Gen<P2<Seq<Integer>, Option<Integer>>> gen = arbSeq(arbInteger).gen.bind(seq -> {
+      if (seq.isEmpty()) {
+        return Gen.value(P.p(seq, none()));
+      } else {
+        return Gen.choose(0, seq.length() - 1).map(i -> P.p(seq, some(i)));
+      }
+    });
+
+    return property(Arbitrary.arbitrary(gen), arbInteger, (pair, n) ->
+      implies(pair._2().isSome(), P.lazy(() -> {
+        final Seq<Integer> seq = pair._1();
+        final int index = pair._2().some();
+        return prop(seq.update(index, n).index(index).equals(n));
+      })));
+  }
+
+  public Property foldLeft() {
+    return property(arbSeq(Arbitrary.arbitrary(Gen.value(1))), seq ->
+      prop(seq.foldLeft((acc, i) -> acc + i, 0) == seq.length()));
+  }
+
+  public Property foldRight() {
+    return property(arbSeq(Arbitrary.arbitrary(Gen.value(1))), seq ->
+      prop(seq.foldRight((i, acc) -> acc + i, 0) == seq.length()));
+  }
+}

--- a/core/src/test/java/fj/runner/PropertyTestRunner.java
+++ b/core/src/test/java/fj/runner/PropertyTestRunner.java
@@ -1,0 +1,55 @@
+package fj.runner;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+
+import fj.P3;
+import fj.data.Option;
+import fj.test.CheckResult;
+import fj.test.Property;
+import fj.test.reflect.Check;
+import fj.test.reflect.CheckParams;
+
+public class PropertyTestRunner extends Runner {
+  private final Class<?> clas;
+
+  public PropertyTestRunner(Class<?> clas) {
+    this.clas = clas;
+  }
+
+  @Override
+  public Description getDescription() {
+    Description suite = Description.createSuiteDescription(clas);
+    for (P3<Property, String, Option<CheckParams>> p : Check.properties(clas)) {
+      suite.addChild(Description.createTestDescription(clas, p._2()));
+    }
+    return suite;
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    for (P3<Property, String, Option<CheckParams>> p : Check.properties(clas)) {
+      Description desc = Description.createTestDescription(clas, p._2());
+      notifier.fireTestStarted(desc);
+      CheckResult result = checkProperty(p._1(), p._3());
+
+      try {
+        CheckResult.summaryEx.showS(result);
+      } catch (Throwable t) {
+        notifier.fireTestFailure(new Failure(desc, t));
+      }
+
+      notifier.fireTestFinished(desc);
+    }
+  }
+
+  private static CheckResult checkProperty(Property prop, Option<CheckParams> params) {
+    for (CheckParams ps : params) {
+      return prop.check(ps.minSuccessful(), ps.maxDiscarded(), ps.minSize(), ps.maxSize());
+    }
+
+    return prop.check();
+  }
+}


### PR DESCRIPTION
Guys, I have a suggestion. FunctionalJava has a decent property based testing framework (fj.test), but it is not used in FunctionalJava. Instead, ScalaCheck is used. I think, we should rewrite all properties to fj.test and remove ScalaCheck dependency.

Here are some advantages of this approach:
* Test classes will be a good example of fj.test usage for programmers that use FunctionalJava.
* It will test fj.test.* classes themselves.
* Programmers will trust fj.test more.
* Scala dependency will be redundant.

Don't get me wrong. I like Scala, but FunctionalJava is a library for Java and it should use Java as much as possible.

I've implemented `PropertyTestRunner` which integrates JUnit with fj.test. All classes that are marked with `RunWith(PropertyTestRunner)` will be executed during the Gradle build. `SeqProperties` is an example of a class with properties (you can run it directly from IDEA too).

I'm open for discussion.