### PR TITLE
Fixed bug in arrayShow

### DIFF
--- a/core/src/main/java/fj/Show.java
+++ b/core/src/main/java/fj/Show.java
@@ -393,7 +393,7 @@ public final class Show<A> {
    */
   public static <A> Show<Array<A>> arrayShow(final Show<A> sa) {
     return show(as -> {
-      Stream<Character> b = nil();
+      Stream<Character> b = fromString("Array(");
 
       for (int i = 0; i < as.length(); i++) {
         b = b.append(sa.f.f(as.get(i)));
@@ -402,9 +402,7 @@ public final class Show<A> {
           b = b.append(fromString(","));
       }
 
-      b = b.append(fromString("Array("));
-
-      return fromString(")").append(p(b));
+      return b.append(fromString(")"));
     });
   }
 


### PR DESCRIPTION
I noticed that the arrayShow method called in the demo gave transposed results:

`)44,22,90,98,1078,6,64,6,42Array(`

This is a fix for that.