### PR TITLE
Removed unnecessary wrapping into SoftReference

### DIFF
--- a/core/src/main/java/fj/P.java
+++ b/core/src/main/java/fj/P.java
@@ -33,9 +33,10 @@ public final class P {
    */
   public static <A> P1<A> p(final A a) {
     return new P1<A>() {
-      public A _1() {
+      @Override public A _1() {
         return a;
       }
+      @Override public P1<A> memo() { return this; }
     };
   }
 


### PR DESCRIPTION
Since `a` was already calculated strictly, there is no need to memoize it.