### PR TITLE
Replaced SoftReference with WeakReference for better performance

### DIFF
--- a/core/src/main/java/fj/Monoid.java
+++ b/core/src/main/java/fj/Monoid.java
@@ -90,6 +90,18 @@ public final class Monoid<A> {
   }
 
   /**
+   * Returns a value summed <code>n</code> times (<code>a + a + ... + a</code>)
+   * @param n multiplier
+   * @param a the value to multiply
+   * @return <code>a</code> summed <code>n</code> times. If <code>n <= 0</code>, returns <code>zero()</code>
+   */
+  public A multiply(final int n, final A a) {
+    A m = zero();
+    for (int i = 0; i < n; i++) { m = sum(m, a); }
+    return m;
+  }
+
+  /**
    * Sums the given values with right-fold.
    *
    * @param as The values to sum.

--- a/core/src/main/java/fj/Ord.java
+++ b/core/src/main/java/fj/Ord.java
@@ -157,6 +157,8 @@ public final class Ord<A> {
    */
   public final F<A, F<A, A>> min = curry((a, a1) -> min(a, a1));
 
+  public final Ord<A> reverse() { return ord(Function.flip(f)); }
+
   /**
    * Returns an order instance that uses the given equality test and ordering function.
    *
@@ -343,14 +345,25 @@ public final class Ord<A> {
    */
   public static <A> Ord<List<A>> listOrd(final Ord<A> oa) {
     return ord(l1 -> l2 -> {
-        if (l1.isEmpty())
-            return l2.isEmpty() ? Ordering.EQ : Ordering.LT;
-        else if (l2.isEmpty())
-            return l1.isEmpty() ? Ordering.EQ : Ordering.GT;
-        else {
-            final Ordering c = oa.compare(l1.head(), l2.head());
-            return c == Ordering.EQ ? listOrd(oa).f.f(l1.tail()).f(l2.tail()) : c;
+      List<A> x1 = l1;
+      List<A> x2 = l2;
+
+      while (x1.isNotEmpty() && x2.isNotEmpty()) {
+        final Ordering o = oa.compare(x1.head(), x2.head());
+        if (o == Ordering.LT || o == Ordering.GT) {
+          return o;
         }
+        x1 = x1.tail();
+        x2 = x2.tail();
+      }
+
+      if (x1.isEmpty() && x2.isEmpty()) {
+        return Ordering.EQ;
+      } else if (x1.isEmpty()) {
+        return Ordering.LT;
+      } else {
+        return Ordering.GT;
+      }
     });
   }
 

--- a/core/src/main/java/fj/Ordering.java
+++ b/core/src/main/java/fj/Ordering.java
@@ -23,6 +23,15 @@ public enum Ordering {
   GT;
 
   public int toInt() { return ordinal() - 1 ; }
+
+  public Ordering reverse() {
+    switch (this) {
+      case LT: return GT;
+      case GT: return LT;
+    }
+    return EQ;
+  }
+
   public static Ordering fromInt(int cmp) {
     return cmp == 0 ? EQ : cmp > 0 ? GT : LT;
   }

--- a/core/src/main/java/fj/P.java
+++ b/core/src/main/java/fj/P.java
@@ -37,6 +37,8 @@ public final class P {
         return a;
       }
       @Override public P1<A> memo() { return this; }
+      @Override public P1<A> weakMemo() { return this; }
+      @Override public P1<A> softMemo() { return this; }
     };
   }
 

--- a/core/src/main/java/fj/P1.java
+++ b/core/src/main/java/fj/P1.java
@@ -1,6 +1,6 @@
 package fj;
 
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 
 import fj.data.Array;
 import fj.data.List;
@@ -216,7 +216,7 @@ public abstract class P1<A> implements F0<A> {
         final P1<A> self = this;
         return new P1<A>() {
           private final Object latch = new Object();
-          private volatile SoftReference<Option<A>> v = null;
+          private volatile WeakReference<Option<A>> v = null;
 
           @Override
           public A _1() {
@@ -226,7 +226,7 @@ public abstract class P1<A> implements F0<A> {
                 o = v != null ? v.get() : null;
                 if (o == null) {
                   o = Option.some(self._1());
-                  v = new SoftReference<>(o);
+                  v = new WeakReference<>(o);
                 }
               }
             }

--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -624,7 +624,7 @@ public abstract class List<A> implements Iterable<A> {
    * @return A new list that has appended the given list.
    */
   public final List<A> append(final List<A> as) {
-    return fromList(this).append(as).toList();
+    return Buffer.fromList(this).prependToList(as);
   }
 
   /**
@@ -1787,7 +1787,7 @@ public abstract class List<A> implements Iterable<A> {
      * Appends (snoc) the given element to this buffer to produce a new buffer.
      *
      * @param a The element to append to this buffer.
-     * @return A new buffer with the given element appended.
+     * @return This buffer.
      */
     public Buffer<A> snoc(final A a) {
       if (exported)
@@ -1806,10 +1806,10 @@ public abstract class List<A> implements Iterable<A> {
     }
 
     /**
-     * Appends the given buffer to this buffer.
+     * Appends the given list to this buffer.
      *
-     * @param as The buffer to append to this one.
-     * @return A new buffer that has appended the given buffer.
+     * @param as The list to append to this buffer.
+     * @return This buffer.
      */
     public Buffer<A> append(final List<A> as) {
       for (List<A> xs = as; xs.isNotEmpty(); xs = xs.tail())
@@ -1817,6 +1817,28 @@ public abstract class List<A> implements Iterable<A> {
 
       return this;
     }
+
+    /**
+     * Prepends the elements of this buffer to the given list.
+     *
+     * @param as the list to which elements are prepended.
+     */
+    public List<A> prependToList(final List<A> as) {
+      if (isEmpty()) {
+        return as;
+      } else {
+        if (exported)
+          copy();
+
+        tail.tail(as);
+        return toList();
+      }
+    }
+
+    /**
+     * Returns <code>true</code> if this buffer is empty, <code>false</code> otherwise.
+     */
+    public boolean isEmpty() { return start.isEmpty(); }
 
     /**
      * Returns an immutable list projection of this buffer. Modifications to the underlying buffer

--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -15,10 +15,8 @@ import fj.P1;
 import fj.P2;
 import fj.Show;
 import fj.Unit;
-import static fj.Function.curry;
-import static fj.Function.constant;
-import static fj.Function.identity;
-import static fj.Function.compose;
+
+import static fj.Function.*;
 import static fj.P.p;
 import static fj.P.p2;
 import static fj.Unit.unit;
@@ -169,9 +167,10 @@ public abstract class List<A> implements Iterable<A> {
    */
   @SuppressWarnings({"unchecked"})
   public final Array<A> toArray() {
-    final Object[] a = new Object[length()];
+    final int length = length();
+    final Object[] a = new Object[length];
     List<A> x = this;
-    for (int i = 0; i < length(); i++) {
+    for (int i = 0; i < length; i++) {
       a[i] = x.head();
       x = x.tail();
     }
@@ -629,14 +628,14 @@ public abstract class List<A> implements Iterable<A> {
   }
 
   /**
-   * Performs a right-fold reduction across this list. This function uses O(length) stack space.
+   * Performs a right-fold reduction across this list.
    *
    * @param f The function to apply on each element of the list.
    * @param b The beginning value to start the application from.
    * @return The final result after the right-fold reduction.
    */
   public final <B> B foldRight(final F<A, F<B, B>> f, final B b) {
-    return isEmpty() ? b : f.f(head()).f(tail().foldRight(f, b));
+    return reverse().foldLeft(flip(f), b);
   }
 
   /**
@@ -1581,7 +1580,9 @@ public abstract class List<A> implements Iterable<A> {
    * @return A list of the given value replicated the given number of times.
    */
   public static <A> List<A> replicate(final int n, final A a) {
-    return n <= 0 ? List.<A>nil() : replicate(n - 1, a).cons(a);
+    List<A> list = List.nil();
+    for (int i = 0; i < n; i++) { list = list.cons(a); }
+    return list;
   }
 
   /**

--- a/core/src/main/java/fj/data/Stream.java
+++ b/core/src/main/java/fj/data/Stream.java
@@ -1233,7 +1233,10 @@ public abstract class Stream<A> implements Iterable<A> {
    *         <code>false</code> otherwise.
    */
   public final boolean forall(final F<A, Boolean> f) {
-    return isEmpty() || f.f(head()) && tail()._1().forall(f);
+    for (final A a : this) {
+      if (!f.f(a)) return false;
+    }
+    return true;
   }
 
   @Override

--- a/core/src/main/java/fj/data/Stream.java
+++ b/core/src/main/java/fj/data/Stream.java
@@ -1430,7 +1430,7 @@ public abstract class Stream<A> implements Iterable<A> {
 
     Cons(final A head, final P1<Stream<A>> tail) {
       this.head = head;
-      this.tail = tail.memo();
+      this.tail = tail.weakMemo();
     }
 
     public A head() {

--- a/props-core/src/test/java/fj/data/properties/ListProperties.java
+++ b/props-core/src/test/java/fj/data/properties/ListProperties.java
@@ -1,8 +1,10 @@
 package fj.data.properties;
 
+import fj.Ord;
 import fj.P;
 import fj.P2;
 import fj.data.List;
+import fj.test.reflect.CheckParams;
 import fj.test.runner.PropertyTestRunner;
 import fj.test.Gen;
 import fj.test.Property;
@@ -18,6 +20,7 @@ import static fj.Equal.intEqual;
  * Created by Zheka Kozlov on 02.06.2015.
  */
 @RunWith(PropertyTestRunner.class)
+@CheckParams(maxSize = 10000)
 public class ListProperties {
 
   public Property isPrefixOf() {
@@ -52,5 +55,15 @@ public class ListProperties {
   public Property isSuffixOfDifferentHeads() {
     return property(arbList(arbInteger), arbList(arbInteger), arbInteger, arbInteger, (list1, list2, h1, h2) ->
       implies(intEqual.notEq(h1, h2), () -> prop(!list1.snoc(h1).isSuffixOf(intEqual, list2.snoc(h2)))));
+  }
+
+  public Property listOrdEqual() {
+    return property(arbList(arbInteger), list -> prop(Ord.listOrd(Ord.intOrd).equal().eq(list, list)));
+  }
+
+  public Property listOrdReverse() {
+    final Ord<List<Integer>> ord = Ord.listOrd(Ord.intOrd);
+    return property(arbList(arbInteger), arbList(arbInteger), (list1, list2) ->
+      prop(ord.compare(list1, list2) == ord.reverse().compare(list1, list2).reverse()));
   }
 }

--- a/props-core/src/test/java/fj/data/properties/NonEmptyListProperties.java
+++ b/props-core/src/test/java/fj/data/properties/NonEmptyListProperties.java
@@ -5,6 +5,7 @@ import fj.Ord;
 import fj.P2;
 import fj.data.List;
 import fj.data.NonEmptyList;
+import fj.test.reflect.CheckParams;
 import fj.test.runner.PropertyTestRunner;
 import fj.test.Property;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import static java.lang.Math.min;
  * Created by Zheka Kozlov on 02.06.2015.
  */
 @RunWith(PropertyTestRunner.class)
+@CheckParams(maxSize = 10000)
 public class NonEmptyListProperties {
 
   private static final Equal<NonEmptyList<Integer>> eq = nonEmptyListEqual(intEqual);

--- a/props-core/src/test/java/fj/data/properties/SeqProperties.java
+++ b/props-core/src/test/java/fj/data/properties/SeqProperties.java
@@ -5,6 +5,7 @@ import fj.P;
 import fj.P2;
 import fj.data.Option;
 import fj.data.Seq;
+import fj.test.reflect.CheckParams;
 import fj.test.runner.PropertyTestRunner;
 import fj.test.Arbitrary;
 import fj.test.Gen;
@@ -24,6 +25,7 @@ import static fj.test.Property.property;
  * Created by Zheka Kozlov on 01.06.2015.
  */
 @RunWith(PropertyTestRunner.class)
+@CheckParams(maxSize = 10000)
 public class SeqProperties {
 
   public Property consHead() {

--- a/quickcheck/src/main/java/fj/test/Gen.java
+++ b/quickcheck/src/main/java/fj/test/Gen.java
@@ -337,15 +337,7 @@ public final class Gen<A> {
    * @return A generator of lists after sequencing the given generators.
    */
   public static <A> Gen<List<A>> sequence(final List<Gen<A>> gs) {
-    return gs.foldRight(new F<Gen<A>, F<Gen<List<A>>, Gen<List<A>>>>() {
-      public F<Gen<List<A>>, Gen<List<A>>> f(final Gen<A> ga) {
-        return new F<Gen<List<A>>, Gen<List<A>>>() {
-          public Gen<List<A>> f(final Gen<List<A>> gas) {
-            return ga.bind(gas, List.<A>cons());
-          }
-        };
-      }
-    }, value(List.<A>nil()));
+    return gen(i -> r -> gs.map(g -> g.gen(i, r)));
   }
 
   /**

--- a/quickcheck/src/main/java/fj/test/reflect/Check.java
+++ b/quickcheck/src/main/java/fj/test/reflect/Check.java
@@ -273,7 +273,7 @@ public final class Check {
           ctor.setAccessible(true);
           return ctor.newInstance();
         } catch(Exception e) {
-          throw error(e.toString());
+          throw new Error(e.getMessage(), e);
         }
       }
     });
@@ -324,7 +324,7 @@ public final class Check {
           final String name = fromNull(m.element().getAnnotation(Name.class)).map(nameS).orSome(m.name());
           return p(m.invoke(t.orSome(P.<T>p(null))), name, params);
         } catch(Exception e) {
-          throw error(e.toString());
+          throw new Error(e.getMessage(), e);
         }
       }
     });


### PR DESCRIPTION
Benchmark:

```java
import com.google.common.base.Stopwatch;
import fj.data.Stream;

public class Main {
    public static void main(String[] args) {
        int to = 3000000;
        Stream<Integer> range = Stream.range(1, 3000000);

        Stopwatch sw = Stopwatch.createStarted();
        Integer sum = range.foldLeft(x -> y -> x + y, 0);
        System.out.println("First run: " + sw.stop());

        sw.start();
        sum = range.foldLeft(x -> y -> x + y, 0);
        System.out.println("Second run: " + sw.stop());
    }
}
```

The result with SoftReference:
```
First run: 13,31 s
Second run: 32,68 s
```

WeakReference:
```
First run: 219,9 ms
Second run: 388,6 ms
```

SoftReference is about 70 times slower.

I also performed a profiling session with JVisualVM. With SoftReference there are 125 collections total and garbage collection took 23 seconds! With WeakReference - 29 collections and 25 milliseconds.