### PR TITLE
Added @SafeVarargs to suppress warnings. Added Seq.toList(), Seq.delete()

### DIFF
--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -1501,7 +1501,7 @@ public abstract class List<A> implements Iterable<A> {
    * @param as The elements to construct a list with.
    * @return A list with the given elements.
    */
-  public static <A> List<A> list(final A... as) {
+  @SafeVarargs public static <A> List<A> list(final A... as) {
     return Array.array(as).toList();
   }
 

--- a/core/src/main/java/fj/data/NonEmptyList.java
+++ b/core/src/main/java/fj/data/NonEmptyList.java
@@ -293,7 +293,7 @@ public final class NonEmptyList<A> implements Iterable<A> {
    * @param tail The elements to construct a list's tail with.
    * @return A non-empty list with the given elements.
    */
-  public static <A> NonEmptyList<A> nel(final A head, final A... tail) {
+  @SafeVarargs public static <A> NonEmptyList<A> nel(final A head, final A... tail) {
     return nel(head, List.list(tail));
   }
 

--- a/core/src/main/java/fj/data/Set.java
+++ b/core/src/main/java/fj/data/Set.java
@@ -475,7 +475,7 @@ public abstract class Set<A> implements Iterable<A> {
    * @param as The elements to add to a set.
    * @return A new set containing the elements of the given iterable.
    */
-  public static <A> Set<A> set(final Ord<A> o, final A ... as) {
+  @SafeVarargs public static <A> Set<A> set(final Ord<A> o, final A ... as) {
     Set<A> s = empty(o);
     for (final A a : as)
       s = s.insert(a);

--- a/core/src/main/java/fj/data/Stream.java
+++ b/core/src/main/java/fj/data/Stream.java
@@ -733,7 +733,7 @@ public abstract class Stream<A> implements Iterable<A> {
    * @param as The elements which which to construct a stream.
    * @return a new stream with the given elements.
    */
-  public static <A> Stream<A> stream(final A... as) {
+  @SafeVarargs public static <A> Stream<A> stream(final A... as) {
     return as.length == 0 ? Stream.<A>nil()
                           : unfold(P2.tuple((as1, i) -> i >= as.length ? Option.<P2<A, P2<A[], Integer>>>none()
                                                 : some(P.p(as[i], P.p(as, i + 1)))), P.p(as, 0));

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -58,7 +58,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    * @param p2s The elements to construct the tree map with.
    * @return a TreeMap with the given elements.
    */
-  public static <K, V> TreeMap<K, V> treeMap(final Ord<K> keyOrd, final P2<K, V>... p2s) {
+  @SafeVarargs public static <K, V> TreeMap<K, V> treeMap(final Ord<K> keyOrd, final P2<K, V>... p2s) {
     return treeMap(keyOrd, List.list(p2s));
   }
 

--- a/props-core/src/test/java/fj/data/properties/SeqProperties.java
+++ b/props-core/src/test/java/fj/data/properties/SeqProperties.java
@@ -103,6 +103,15 @@ public class SeqProperties {
     });
   }
 
+  @CheckParams(minSize = 1)
+  public Property delete() {
+    return property(arbSeqWithIndex, arbInteger, (pair, n) -> {
+      final Seq<Integer> seq = pair._1();
+      final int index = pair._2();
+      return prop(seq.delete(index).length() == seq.length() - 1);
+    });
+  }
+
   public Property foldLeft() {
     return property(arbSeq(arbitrary(Gen.value(1))), seq ->
       prop(seq.foldLeft((acc, i) -> acc + i, 0) == seq.length()));


### PR DESCRIPTION
IDE reports a warning for the following code:

```java
List.list(List.list(1), List.list(2)); // Type safety: A generic array of List<Integer> is created for a varargs parameter
```

I added @SafeVarargs annotation to mark varargs methods as safe.