### PR TITLE
Fixed bug in Buffer.copy()

### DIFF
--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -1986,6 +1986,7 @@ public abstract class List<A> implements Iterable<A> {
       List<A> s = start;
       final Cons<A> t = tail;
       start = nil();
+      tail = null;
       exported = false;
       while (s != t) {
         snoc(s.head());


### PR DESCRIPTION
There was a bug in copy():

```java
Buffer<Integer> buf = Buffer.empty();
System.out.println(buf.snoc(1).snoc(2).snoc(3).toList());
System.out.println(buf.snoc(4).toList()); // Prints List() instead of List(1,2,3,4)
```