### PR TITLE
#235 fj.test.Gen.pick is broken and #237 fj.test.Rand.reseed() is broken

### DIFF
--- a/quickcheck/src/main/java/fj/test/Gen.java
+++ b/quickcheck/src/main/java/fj/test/Gen.java
@@ -1,25 +1,28 @@
 package fj.test;
 
-import static fj.Bottom.error;
-import fj.Effect;
 import fj.F;
 import fj.Function;
-import static fj.Function.flip;
-import static fj.Function.curry;
 import fj.P2;
-import static fj.P2.__1;
 import fj.Unit;
-import fj.F2;
-import static fj.data.Array.array;
+import fj.control.Trampoline;
+import fj.data.Array;
 import fj.data.List;
-import static fj.data.List.nil;
-import static fj.data.List.replicate;
 import fj.data.Option;
 import fj.function.Effect1;
 
+import static fj.Bottom.error;
+import static fj.Function.curry;
+import static fj.Function.flip;
 import static fj.Monoid.intAdditionMonoid;
 import static fj.Ord.intOrd;
-
+import static fj.P.lazy;
+import static fj.P2.__1;
+import static fj.control.Trampoline.pure;
+import static fj.control.Trampoline.suspend;
+import static fj.data.Array.array;
+import static fj.data.List.cons;
+import static fj.data.List.nil;
+import static fj.data.List.replicate;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -564,43 +567,215 @@ public final class Gen<A> {
    * Returns a generator of lists that picks the given number of elements from the given list. If
    * the given number is less than zero or greater than the length of the given list, then the
    * returned generator will never produce a value.
+   * <p>
+   * Note: pick is synonymous with pickCombinationWithoutReplacement
    *
    * @param n  The number of elements to pick from the given list.
    * @param as The list from which to pick elements.
    * @return A generator of lists that picks the given number of elements from the given list.
    */
-  public static <A> Gen<List<A>> pick(final int n, final List<A> as) {
-    return n < 0 || n > as.length() ? Gen.<List<A>>fail() : sequenceN(n, choose(0, as.length() - 1)).map(new F<List<Integer>, List<A>>() {
-      public List<A> f(final List<Integer> is) {
-        List<A> r = nil();
+  @Deprecated
+  public static <A> Gen<List<A>> pick(int n, List<A> as) {
+    return pickCombinationWithoutReplacement(n, as);
+  }
 
-        List<Integer> iis = is.sort(intOrd);
-        List<P2<A, Integer>> aas = as.zipIndex();
+  /**
+   * Returns a generator of lists that picks the given number of elements from the given list. The selection is
+   * a combination without replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list will always contain its elements in the same order</li>
+   * <li>An element will never be picked more than once</li>
+   * </ul>
+   * <p>
+   * If the given number is less than zero or greater than the length of the given list, then the
+   * returned generator will never produce a value.
+   *
+   * @param n  The number of elements to pick from the given list.
+   * @param as The list from which to pick elements.
+   * @return A generator of lists that picks the given number of elements from the given list.
+   */
+  public static <A> Gen<List<A>> pickCombinationWithoutReplacement(int n, List<A> as) {
+    int aLength = as.length();
+    return ((n >= 0) && (n <= aLength)) ?
+        parameterised(s -> r -> {
+          final class Tramp {
 
-        //noinspection ForLoopWithMissingComponent
-        for(; iis.isNotEmpty() && aas.isNotEmpty(); aas = aas.tail())
-          if(iis.head().equals(aas.head()._2()))
-            iis = iis.tail();
-          else
-            r = r.snoc(aas.head()._1());
+            // Picks elements in constant stack space
+            private Trampoline<List<A>> tramp(List<A> remainAs, int remainN, int remainALength) {
+              return suspend(lazy(() ->
+                  (remainN == 0) ?
+                      // We have picked N elements; stop
+                      pure(nil()) :
+                      // For M remaining elements of which N will be picked, pick remainAs.head() with probability N/M
+                      (r.choose(0, remainALength - 1) < remainN) ?
+                          tramp(remainAs.tail(), remainN - 1, remainALength - 1)
+                              .map(pickedTail -> cons(remainAs.head(), pickedTail)) :
+                          tramp(remainAs.tail(), remainN, remainALength - 1)));
+            }
 
-        return r;
-      }
-    });
+          }
+          return value(new Tramp().tramp(as, n, aLength).run());
+        }) :
+        fail();
+  }
+
+  /**
+   * Returns a generator of lists that picks the given number of elements from the given list. The selection is
+   * a combination with replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list will always contain its elements in the same order</li>
+   * <li>Each element may be picked more than once</li>
+   * </ul>
+   * <p>
+   * If the given number is less than zero, then the returned generator will never produce a value. Note that,
+   * with replacement, the given number may be larger than the length of the given list.
+   *
+   * @param n  The number of elements to pick from the given list.
+   * @param as The list from which to pick elements.
+   * @return A generator of lists that picks the given number of elements from the given list.
+   */
+  public static <A> Gen<List<A>> pickCombinationWithReplacement(int n, List<A> as) {
+    Array<A> aArr = as.toArray();
+    return (n >= 0) ?
+        pick(indexPermutation(n, aArr.length()).map(indexes -> indexes.sort(intOrd)), aArr) :
+        fail();
+  }
+
+  /**
+   * Returns a generator of lists that picks the given number of elements from the given list. The selection is
+   * a permutation without replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list may contain its elements in any order</li>
+   * <li>An element will never be picked more than once</li>
+   * </ul>
+   * <p>
+   * If the given number is less than zero or greater than the length of the given list, then the
+   * returned generator will never produce a value.
+   *
+   * @param n  The number of elements to pick from the given list.
+   * @param as The list from which to pick elements.
+   * @return A generator of lists that picks the given number of elements from the given list.
+   */
+  public static <A> Gen<List<A>> pickPermutationWithoutReplacement(int n, List<A> as) {
+    return parameterised(s -> r ->
+        pickCombinationWithoutReplacement(n, as).map(combination -> {
+          // Shuffle combination using the Fisher-Yates algorithm
+          Array<A> aArr = combination.toArray();
+          int length = aArr.length();
+          for (int i = length - 1; i > 0; --i) {
+            int j = r.choose(0, i);
+            A tmp = aArr.get(i);
+            aArr.set(i, aArr.get(j));
+            aArr.set(j, tmp);
+          }
+          return aArr.toList();
+        }));
+  }
+
+  /**
+   * Returns a generator of lists that picks the given number of elements from the given list. The selection is
+   * a permutation with replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list may contain its elements in any order</li>
+   * <li>Each element may be picked more than once</li>
+   * </ul>
+   * <p>
+   * If the given number is less than zero, then the returned generator will never produce a value. Note that,
+   * with replacement, the given number may be larger than the length of the given list.
+   *
+   * @param n  The number of elements to pick from the given list.
+   * @param as The list from which to pick elements.
+   * @return A generator of lists that picks the given number of elements from the given list.
+   */
+  public static <A> Gen<List<A>> pickPermutationWithReplacement(int n, List<A> as) {
+    Array<A> aArr = as.toArray();
+    return (n >= 0) ?
+        pick(indexPermutation(n, aArr.length()), aArr) :
+        fail();
+  }
+
+  private static Gen<List<Integer>> indexPermutation(int n, int m) {
+    return sequenceN(n, choose(0, m - 1));
+  }
+
+  private static <A> Gen<List<A>> pick(Gen<List<Integer>> indexesGen, Array<A> as) {
+    return indexesGen.map(indexes ->
+        indexes.foldLeft((acc, index) -> cons(as.get(index), acc), List.<A>nil()).reverse());
   }
 
   /**
    * Returns a generator of lists that produces some of the values of the given list.
+   * <p>
+   * Note: someOf is synonymous with someCombinationWithoutReplacementOf
    *
    * @param as The list from which to pick values.
    * @return A generator of lists that produces some of the values of the given list.
    */
-  public static <A> Gen<List<A>> someOf(final List<A> as) {
-    return choose(0, as.length()).bind(new F<Integer, Gen<List<A>>>() {
-      public Gen<List<A>> f(final Integer i) {
-        return pick(i, as);
-      }
-    });
+  @Deprecated
+  public static <A> Gen<List<A>> someOf(List<A> as) {
+    return someCombinationWithoutReplacementOf(as);
+  }
+
+  /**
+   * Returns a generator of lists that produces some of the values of the given list. The selection is
+   * a combination without replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list will always contain its elements in the same order</li>
+   * <li>An element will never be picked more than once</li>
+   * </ul>
+   *
+   * @param as The list from which to pick values.
+   * @return A generator of lists that produces some of the values of the given list.
+   */
+  public static <A> Gen<List<A>> someCombinationWithoutReplacementOf(List<A> as) {
+    return choose(0, as.length()).bind(n -> pickCombinationWithoutReplacement(n, as));
+  }
+
+  /**
+   * Returns a generator of lists that produces some of the values of the given list. The selection is
+   * a combination with replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list will always contain its elements in the same order</li>
+   * <li>Each element may be picked more than once</li>
+   * </ul>
+   *
+   * @param maxLength The maximum length of a generated list
+   * @param as        The list from which to pick values.
+   * @return A generator of lists that produces some of the values of the given list.
+   */
+  public static <A> Gen<List<A>> someCombinationWithReplacementOf(int maxLength, List<A> as) {
+    return choose(0, maxLength).bind(n -> pickCombinationWithReplacement(n, as));
+  }
+
+  /**
+   * Returns a generator of lists that produces some of the values of the given list. The selection is
+   * a permutation without replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list may contain its elements in any order</li>
+   * <li>An element will never be picked more than once</li>
+   * </ul>
+   *
+   * @param as The list from which to pick values.
+   * @return A generator of lists that produces some of the values of the given list.
+   */
+  public static <A> Gen<List<A>> somePermutationWithoutReplacementOf(List<A> as) {
+    return choose(0, as.length()).bind(n -> pickPermutationWithoutReplacement(n, as));
+  }
+
+  /**
+   * Returns a generator of lists that produces some of the values of the given list. The selection is
+   * a permutation with replacement of elements from the given list, i.e.
+   * <ul>
+   * <li>For any given selection, a generated list may contain its elements in any order</li>
+   * <li>Each element may be picked more than once</li>
+   * </ul>
+   *
+   * @param maxLength The maximum length of a generated list
+   * @param as        The list from which to pick values.
+   * @return A generator of lists that produces some of the values of the given list.
+   */
+  public static <A> Gen<List<A>> somePermutationWithReplacementOf(int maxLength, List<A> as) {
+    return choose(0, maxLength).bind(n -> pickPermutationWithReplacement(n, as));
   }
 
   /**

--- a/quickcheck/src/main/java/fj/test/Property.java
+++ b/quickcheck/src/main/java/fj/test/Property.java
@@ -184,7 +184,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator} and the given
+   * Checks this property using a {@link Rand#standard standard random generator} and the given
    * arguments to produce a result.
    *
    * @param minSuccessful The minimum number of successful tests before a result is reached.
@@ -226,7 +226,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, 100 minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, 100 minimum
    * successful checks, 500 maximum discarded tests and the given arguments to produce a result.
    *
    * @param minSize The minimum size to use for checking.
@@ -239,7 +239,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, 100 minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, 100 minimum
    * successful checks, 500 maximum discarded tests, minimum size of 0, maximum size of 100.
    *
    * @return A result after checking this property.
@@ -249,7 +249,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, the given minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, the given minimum
    * successful checks, 500 maximum discarded tests, minimum size of 0, maximum size of 100.
    *
    * @param minSuccessful The minimum number of successful tests before a result is reached.
@@ -272,7 +272,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, 100 minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, 100 minimum
    * successful checks, the given maximum discarded tests, minimum size of 0, maximum size of 100.
    *
    * @param maxDiscarded The maximum number of tests discarded because they did not satisfy
@@ -297,7 +297,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, 100 minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, 100 minimum
    * successful checks, 500 maximum discarded tests, the given minimum size, maximum size of 100.
    *
    * @param minSize The minimum size to use for checking.
@@ -320,7 +320,7 @@ public final class Property {
   }
 
   /**
-   * Checks this property using a {@link Rand#Rand(F, F) standard random generator}, 100 minimum
+   * Checks this property using a {@link Rand#standard standard random generator}, 100 minimum
    * successful checks, 500 maximum discarded tests, minimum size of 0, the given maximum size.
    *
    * @param maxSize The maximum size to use for checking.

--- a/quickcheck/src/main/java/fj/test/Rand.java
+++ b/quickcheck/src/main/java/fj/test/Rand.java
@@ -2,11 +2,13 @@ package fj.test;
 
 import fj.F;
 import fj.data.Option;
-import static fj.data.Option.some;
 
+import java.util.Random;
+
+import static fj.data.Option.none;
+import static fj.data.Option.some;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import java.util.Random;
 
 /**
  * A random number generator.
@@ -17,9 +19,17 @@ public final class Rand {
   private final F<Option<Long>, F<Integer, F<Integer, Integer>>> f;
   private final F<Option<Long>, F<Double, F<Double, Double>>> g;
 
-  private Rand(final F<Option<Long>, F<Integer, F<Integer, Integer>>> f, final F<Option<Long>, F<Double, F<Double, Double>>> g) {
+  // TODO Change to F<Long,Rand> when rand(f,g) is removed
+  private final Option<F<Long, Rand>> optOnReseed;
+
+  private Rand(
+      F<Option<Long>, F<Integer, F<Integer, Integer>>> f,
+      F<Option<Long>, F<Double, F<Double, Double>>> g,
+      Option<F<Long, Rand>> optOnReseed) {
+
     this.f = f;
     this.g = g;
+    this.optOnReseed = optOnReseed;
   }
 
   /**
@@ -74,65 +84,97 @@ public final class Rand {
    * @param seed The seed of the new random generator.
    * @return A random generator with the given seed.
    */
-  public Rand reseed(final long seed) {
-    return new Rand(new F<Option<Long>, F<Integer, F<Integer, Integer>>>() {
-      public F<Integer, F<Integer, Integer>> f(final Option<Long> old) {
-        return new F<Integer, F<Integer, Integer>>() {
-          public F<Integer, Integer> f(final Integer from) {
-            return new F<Integer, Integer>() {
-              public Integer f(final Integer to) {
-                return f.f(some(seed)).f(from).f(to);
-              }
-            };
-          }
-        };
-      }
-    }, new F<Option<Long>, F<Double, F<Double, Double>>>() {
-      public F<Double, F<Double, Double>> f(final Option<Long> old) {
-        return new F<Double, F<Double, Double>>() {
-          public F<Double, Double> f(final Double from) {
-            return new F<Double, Double>() {
-              public Double f(final Double to) {
-                return g.f(some(seed)).f(from).f(to);
-              }
-            };
-          }
-        };
-      }
-    });
+  public Rand reseed(long seed) {
+    return optOnReseed.<Rand>option(
+        () -> {
+          throw new IllegalStateException("reseed() called on a Rand created with deprecated rand() method");
+        },
+        onReseed -> onReseed.f(seed));
   }
 
   /**
    * Constructs a random generator from the given functions that supply a range to produce a
    * result.
+   * <p>
+   * Calling {@link #reseed(long)} on an instance returned from this method will
+   * result in an exception being thrown. Use {@link #rand(F, F, F)} instead.
    *
    * @param f The integer random generator.
    * @param g The floating-point random generator.
    * @return A random generator from the given functions that supply a range to produce a result.
    */
-  public static Rand rand(final F<Option<Long>, F<Integer, F<Integer, Integer>>> f, final F<Option<Long>, F<Double, F<Double, Double>>> g) {
-    return new Rand(f, g);
+  // TODO Change Option<F<Long,Rand>> optOnReseed to F<Long,Road> onReseed when removing this method
+  @Deprecated
+  public static Rand rand(
+      F<Option<Long>, F<Integer, F<Integer, Integer>>> f,
+      F<Option<Long>, F<Double, F<Double, Double>>> g) {
+
+    return new Rand(f, g, none());
   }
 
+  /**
+   * Constructs a reseedable random generator from the given functions that supply a range to produce a
+   * result.
+   *
+   * @param f        The integer random generator.
+   * @param g        The floating-point random generator.
+   * @param onReseed Function to create a reseeded Rand.
+   * @return A random generator from the given functions that supply a range to produce a result.
+   */
+  public static Rand rand(
+      F<Option<Long>, F<Integer, F<Integer, Integer>>> f,
+      F<Option<Long>, F<Double, F<Double, Double>>> g,
+      F<Long, Rand> onReseed) {
 
-  private static final F<Long, Random> fr = new F<Long, Random>() {
-    public Random f(final Long x) {
-      return new Random(x);
-    }
-  };
+    return new Rand(f, g, some(onReseed));
+  }
 
   /**
    * A standard random generator that uses {@link Random}.
    */
-  public static final Rand standard = new Rand(seed -> from -> to -> {
-    final int min = min(from, to);
-    final int max = max(from, to);
-    final Random random = seed.map(fr).orSome(new Random());
-    return (int) ((random.nextLong() & Long.MAX_VALUE) % (1L + max - min)) + min;
-  }, seed -> from -> to -> {
-    final double min = min(from, to);
-    final double max = max(from, to);
-    final Random random = seed.map(fr).orSome(new Random());
-    return random.nextDouble() * (max - min) + min;
-  });
+  public static final Rand standard = createStandard(new Random());
+
+  private static Rand createStandard(Random defaultRandom) {
+    return rand(
+        optSeed -> from -> to ->
+            standardChooseInt(optSeed.<Random>option(() -> defaultRandom, Random::new), from, to),
+        optSeed -> from -> to ->
+            standardChooseDbl(optSeed.<Random>option(() -> defaultRandom, Random::new), from, to),
+        newSeed -> createStandard(new Random(newSeed)));
+  }
+
+  /*
+   * Returns a uniformly distributed value between min(from,to) (inclusive) and max(from,to) (inclusive).
+   */
+  private static int standardChooseInt(Random random, int from, int to) {
+    int result;
+    if (from != to) {
+      int min = min(from, to);
+      int max = max(from, to);
+      long range = (1L + max) - min;
+      long bound = Long.MAX_VALUE - (Long.MAX_VALUE % range);
+      long r = random.nextLong() & Long.MAX_VALUE;
+      while (r >= bound) {
+        // Ensure uniformity
+        r = random.nextLong() & Long.MAX_VALUE;
+      }
+      result = (int) ((r % range) + min);
+    } else {
+      result = from;
+    }
+    return result;
+  }
+
+  /*
+   * Returns a uniformly distributed value between min(from,to) (inclusive) and max(from,to) (exclusive)
+   *
+   * In theory, this differs from the choose() contract, which specifies a closed interval.
+   * In practice, the difference shouldn't matter.
+   */
+  private static double standardChooseDbl(Random random, double from, double to) {
+    double min = min(from, to);
+    double max = max(from, to);
+    return ((max - min) * random.nextDouble()) + min;
+  }
+
 }

--- a/quickcheck/src/test/java/fj/test/GenTest.java
+++ b/quickcheck/src/test/java/fj/test/GenTest.java
@@ -7,29 +7,29 @@ import org.junit.Test;
 import static fj.Ord.charOrd;
 import static fj.data.List.list;
 import static fj.data.List.range;
-import static fj.test.Gen.pickCombinationWithReplacement;
-import static fj.test.Gen.pickCombinationWithoutReplacement;
-import static fj.test.Gen.pickPermutationWithReplacement;
-import static fj.test.Gen.pickPermutationWithoutReplacement;
+import static fj.test.Gen.selectionOf;
+import static fj.test.Gen.combinationOf;
+import static fj.test.Gen.wordOf;
+import static fj.test.Gen.permutationOf;
 import static fj.test.Rand.standard;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public final class TestGen {
+public final class GenTest {
 
   private static final List<Character> AS = list('A', 'B', 'C');
 
   @Test
-  public void testPickCombinationWithoutReplacement_none() {
-    Gen<List<Character>> instance = pickCombinationWithoutReplacement(0, AS);
+  public void testCombinationOf_none() {
+    Gen<List<Character>> instance = combinationOf(0, AS);
     testPick(100, instance, actual -> {
       assertTrue(actual.isEmpty());
     });
   }
 
   @Test
-  public void testPickCombinationWithoutReplacement_one() {
-    Gen<List<Character>> instance = pickCombinationWithoutReplacement(1, AS);
+  public void testCombinationOf_one() {
+    Gen<List<Character>> instance = combinationOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
       assertTrue(AS.exists(a -> a.equals(actual.head())));
@@ -37,8 +37,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithoutReplacement_two() {
-    Gen<List<Character>> instance = pickCombinationWithoutReplacement(2, AS);
+  public void testCombinationOf_two() {
+    Gen<List<Character>> instance = combinationOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -47,8 +47,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithoutReplacement_three() {
-    Gen<List<Character>> instance = pickCombinationWithoutReplacement(3, AS);
+  public void testCombinationOf_three() {
+    Gen<List<Character>> instance = combinationOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -57,16 +57,16 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithReplacement_none() {
-    Gen<List<Character>> instance = pickCombinationWithReplacement(0, AS);
+  public void testSelectionOf_none() {
+    Gen<List<Character>> instance = selectionOf(0, AS);
     testPick(100, instance, actual -> {
       assertTrue(actual.isEmpty());
     });
   }
 
   @Test
-  public void testPickCombinationWithReplacement_one() {
-    Gen<List<Character>> instance = pickCombinationWithReplacement(1, AS);
+  public void testSelectionOf_one() {
+    Gen<List<Character>> instance = selectionOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
       assertTrue(AS.exists(a -> a.equals(actual.head())));
@@ -74,8 +74,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithReplacement_two() {
-    Gen<List<Character>> instance = pickCombinationWithReplacement(2, AS);
+  public void testSelectionOf_two() {
+    Gen<List<Character>> instance = selectionOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -84,8 +84,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithReplacement_three() {
-    Gen<List<Character>> instance = pickCombinationWithReplacement(3, AS);
+  public void testSelectionOf_three() {
+    Gen<List<Character>> instance = selectionOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -94,8 +94,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickCombinationWithReplacement_four() {
-    Gen<List<Character>> instance = pickCombinationWithReplacement(4, AS);
+  public void testSelectionOf_four() {
+    Gen<List<Character>> instance = selectionOf(4, AS);
     testPick(100, instance, actual -> {
       assertEquals(4, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -104,16 +104,16 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithoutReplacement_none() {
-    Gen<List<Character>> instance = pickPermutationWithoutReplacement(0, AS);
+  public void testPermutationOf_none() {
+    Gen<List<Character>> instance = permutationOf(0, AS);
     testPick(100, instance, actual -> {
       assertTrue(actual.isEmpty());
     });
   }
 
   @Test
-  public void testPickPermutationWithoutReplacement_one() {
-    Gen<List<Character>> instance = pickPermutationWithoutReplacement(1, AS);
+  public void testPermutationOf_one() {
+    Gen<List<Character>> instance = permutationOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
       assertTrue(AS.exists(a -> a.equals(actual.head())));
@@ -121,8 +121,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithoutReplacement_two() {
-    Gen<List<Character>> instance = pickCombinationWithoutReplacement(2, AS);
+  public void testPermutationOf_two() {
+    Gen<List<Character>> instance = combinationOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
       assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !a.equals(l.head()))));
@@ -130,8 +130,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithoutReplacement_three() {
-    Gen<List<Character>> instance = pickPermutationWithoutReplacement(3, AS);
+  public void testPermutationOf_three() {
+    Gen<List<Character>> instance = permutationOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -140,16 +140,16 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithReplacement_none() {
-    Gen<List<Character>> instance = pickPermutationWithReplacement(0, AS);
+  public void testWordOf_none() {
+    Gen<List<Character>> instance = wordOf(0, AS);
     testPick(100, instance, actual -> {
       assertTrue(actual.isEmpty());
     });
   }
 
   @Test
-  public void testPickPermutationWithReplacement_one() {
-    Gen<List<Character>> instance = pickPermutationWithReplacement(1, AS);
+  public void testWordOf_one() {
+    Gen<List<Character>> instance = wordOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
       assertTrue(AS.exists(a -> a.equals(actual.head())));
@@ -157,8 +157,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithReplacement_two() {
-    Gen<List<Character>> instance = pickPermutationWithReplacement(2, AS);
+  public void testWordOf_two() {
+    Gen<List<Character>> instance = wordOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -166,8 +166,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithReplacement_three() {
-    Gen<List<Character>> instance = pickPermutationWithReplacement(3, AS);
+  public void testWordOf_three() {
+    Gen<List<Character>> instance = wordOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -175,8 +175,8 @@ public final class TestGen {
   }
 
   @Test
-  public void testPickPermutationWithReplacement_four() {
-    Gen<List<Character>> instance = pickPermutationWithReplacement(4, AS);
+  public void testWordOf_four() {
+    Gen<List<Character>> instance = wordOf(4, AS);
     testPick(100, instance, actual -> {
       assertEquals(4, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
@@ -184,7 +184,7 @@ public final class TestGen {
   }
 
   private static <A> void testPick(int n, Gen<List<A>> instance, Effect1<List<A>> test) {
-    range(0, n).map(i -> instance.gen(0, standard)).foreachDoEffect(test::f);
+    range(0, n).map(ignore -> instance.gen(0, standard)).foreachDoEffect(test::f);
   }
 
 }

--- a/quickcheck/src/test/java/fj/test/TestGen.java
+++ b/quickcheck/src/test/java/fj/test/TestGen.java
@@ -1,0 +1,190 @@
+package fj.test;
+
+import fj.data.List;
+import fj.function.Effect1;
+import org.junit.Test;
+
+import static fj.Ord.charOrd;
+import static fj.data.List.list;
+import static fj.data.List.range;
+import static fj.test.Gen.pickCombinationWithReplacement;
+import static fj.test.Gen.pickCombinationWithoutReplacement;
+import static fj.test.Gen.pickPermutationWithReplacement;
+import static fj.test.Gen.pickPermutationWithoutReplacement;
+import static fj.test.Rand.standard;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class TestGen {
+
+  private static final List<Character> AS = list('A', 'B', 'C');
+
+  @Test
+  public void testPickCombinationWithoutReplacement_none() {
+    Gen<List<Character>> instance = pickCombinationWithoutReplacement(0, AS);
+    testPick(100, instance, actual -> {
+      assertTrue(actual.isEmpty());
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithoutReplacement_one() {
+    Gen<List<Character>> instance = pickCombinationWithoutReplacement(1, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(1, actual.length());
+      assertTrue(AS.exists(a -> a.equals(actual.head())));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithoutReplacement_two() {
+    Gen<List<Character>> instance = pickCombinationWithoutReplacement(2, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(2, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> charOrd.isGreaterThan(a, l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithoutReplacement_three() {
+    Gen<List<Character>> instance = pickCombinationWithoutReplacement(3, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(3, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> charOrd.isGreaterThan(a, l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithReplacement_none() {
+    Gen<List<Character>> instance = pickCombinationWithReplacement(0, AS);
+    testPick(100, instance, actual -> {
+      assertTrue(actual.isEmpty());
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithReplacement_one() {
+    Gen<List<Character>> instance = pickCombinationWithReplacement(1, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(1, actual.length());
+      assertTrue(AS.exists(a -> a.equals(actual.head())));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithReplacement_two() {
+    Gen<List<Character>> instance = pickCombinationWithReplacement(2, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(2, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !charOrd.isLessThan(a, l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithReplacement_three() {
+    Gen<List<Character>> instance = pickCombinationWithReplacement(3, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(3, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !charOrd.isLessThan(a, l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickCombinationWithReplacement_four() {
+    Gen<List<Character>> instance = pickCombinationWithReplacement(4, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(4, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !charOrd.isLessThan(a, l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithoutReplacement_none() {
+    Gen<List<Character>> instance = pickPermutationWithoutReplacement(0, AS);
+    testPick(100, instance, actual -> {
+      assertTrue(actual.isEmpty());
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithoutReplacement_one() {
+    Gen<List<Character>> instance = pickPermutationWithoutReplacement(1, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(1, actual.length());
+      assertTrue(AS.exists(a -> a.equals(actual.head())));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithoutReplacement_two() {
+    Gen<List<Character>> instance = pickCombinationWithoutReplacement(2, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(2, actual.length());
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !a.equals(l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithoutReplacement_three() {
+    Gen<List<Character>> instance = pickPermutationWithoutReplacement(3, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(3, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+      assertTrue(actual.tails().forall(l -> l.isEmpty() || l.tail().forall(a -> !a.equals(l.head()))));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithReplacement_none() {
+    Gen<List<Character>> instance = pickPermutationWithReplacement(0, AS);
+    testPick(100, instance, actual -> {
+      assertTrue(actual.isEmpty());
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithReplacement_one() {
+    Gen<List<Character>> instance = pickPermutationWithReplacement(1, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(1, actual.length());
+      assertTrue(AS.exists(a -> a.equals(actual.head())));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithReplacement_two() {
+    Gen<List<Character>> instance = pickPermutationWithReplacement(2, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(2, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithReplacement_three() {
+    Gen<List<Character>> instance = pickPermutationWithReplacement(3, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(3, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+    });
+  }
+
+  @Test
+  public void testPickPermutationWithReplacement_four() {
+    Gen<List<Character>> instance = pickPermutationWithReplacement(4, AS);
+    testPick(100, instance, actual -> {
+      assertEquals(4, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+    });
+  }
+
+  private static <A> void testPick(int n, Gen<List<A>> instance, Effect1<List<A>> test) {
+    range(0, n).map(i -> instance.gen(0, standard)).foreachDoEffect(test::f);
+  }
+
+}

--- a/quickcheck/src/test/java/fj/test/TestRand.java
+++ b/quickcheck/src/test/java/fj/test/TestRand.java
@@ -1,7 +1,10 @@
 package fj.test;
 
+import fj.Equal;
 import fj.Ord;
+import fj.data.List;
 import fj.data.Stream;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -20,5 +23,19 @@ public class TestRand {
 //        System.out.println(s);
         assertTrue(s.head() == min && s.last() == max);
     }
+
+  @Test
+  public void testReseed() {
+    Rand rand1 = Rand.standard.reseed(42);
+    List<Integer> s1 =
+        List.range(0, 10).map(i -> rand1.choose(Integer.MIN_VALUE, Integer.MAX_VALUE));
+
+    Rand rand2 = rand1.reseed(42);
+    List<Integer> s2 =
+        List.range(0, 10).map(i -> rand2.choose(Integer.MIN_VALUE, Integer.MAX_VALUE));
+
+    assertTrue(s1.zip(s2).forall(p -> p._1().equals(p._2())));
+    Assert.assertFalse(s1.allEqual(Equal.intEqual));
+  }
 
 }


### PR DESCRIPTION
K, this is my first non-trivial contribution to any open source project, so bear with me if I don't follow protocol properly :) There's a change summary at the end of this text.

This pull request addresses the #235 issue, fixing a broken Gen.pick(). As I suggested in my comments on that issue, pick() really ought to come in four flavors: Combination/Permutation, with/without replacement. The same goes for Gen.someOf().

Re my comment on the #235 issue: Although the current implementation of pick() seems to suggest that it was supposed to be with replacement, the JavaDoc implies that it should be without replacement (i.e. the generated lists can't be larger than the source list), so my fixed version of pick() will generate combinations without replacement.

I maintain that pick() and someOf() ought to be deprecated, though. I don't like imbalances ;)

Some technical notes:

There is a shuffle algorithm in there - it is imperative, since no purely functional O(n) shuffle algorithms exist, as far as I know. It shouldn't be a problem, though, since the function is pure on the outside.

I have tried to make all the new functions stack safe, but no guarantees from my part. This whole FP paradigm is still new to me (about 1/2 year).

I noticed that GitHub's file compare util seemed to get really confused over my proposed changes, so here's a summary of them:

- Deprecated pick, calls pickCombinationWithoutReplacement for now
- Added pickCombinationWithoutReplacement
- Added pickCombinationWithReplacement
- Added pickPermutationWithoutReplacement
- Added pickPermutationWithReplacement
- Deprecated someOf, calls someCombinationWithoutReplacementOf for now
- Added someCombinationWithoutReplacementOf
- Added someCombinationWithReplacementOf
- Added somePermutationWithoutReplacementOf
- Added somePermutationWithReplacementOf
- And some private helper functions
- Unit tests