### PR TITLE
Update to latest retrolambda release and gradle plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,8 @@ ext {
 buildscript {
     ext {
 		uptodateVersion = "1.6.0"
-        retrolambdaVersion = "3.2.0"
+        retrolambdaPluginVersion = "3.2.5"
+        retrolambdaVersion = "2.3.0"
     }
 
     repositories {
@@ -18,11 +19,10 @@ buildscript {
 
     dependencies {
         classpath "com.ofg:uptodate-gradle-plugin:$uptodateVersion"
-        classpath "me.tatarka:gradle-retrolambda:$retrolambdaVersion"
+        classpath "me.tatarka:gradle-retrolambda:$retrolambdaPluginVersion"
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
     }
 }
-
 
 apply plugin: "jacoco"
 apply plugin: 'com.github.kt3k.coveralls'

--- a/lib.gradle
+++ b/lib.gradle
@@ -90,6 +90,9 @@ void configureRetroLambda(boolean useRetroLambda, String newJdkEnvVar, String ol
             oldJdk System.getenv(oldJdkEnvVar)
             javaVersion retroLambdaTarget
         }
+        dependencies {
+            retrolambdaConfig "net.orfjackal.retrolambda:retrolambda:$retrolambdaVersion"
+        }
     }
 }
 


### PR DESCRIPTION
Retro lambda 2.3.0 reduce by ~5% the number of generated methods.
cf. https://github.com/orfjackal/retrolambda#version-history