### PR TITLE
Exclude demo subproject from Coveralls

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -8,7 +8,13 @@ archivesBaseName = "${project.projectName}-${project.name}"
 configureAllRetroLambda()
 
 dependencies {
-	compile project(":core")
-	compile project(":quickcheck")
+    compile project(":core")
+    compile project(":quickcheck")
     testCompile dependencyJunit
+}
+
+test {
+    jacoco {
+        enabled = false
+    }
 }


### PR DESCRIPTION
I'm not sure this excludes, I couldn't get coveralls generated for my fork.