### PR TITLE
Stack stafe state

### DIFF
--- a/core/src/main/java/fj/data/State.java
+++ b/core/src/main/java/fj/data/State.java
@@ -1,118 +1,119 @@
 package fj.data;
 
-import fj.*;
+import fj.F;
+import fj.P2;
+import fj.Unit;
+import fj.control.Trampoline;
 
+import static fj.P.lazy;
 import static fj.P.p;
+import static fj.control.Trampoline.suspend;
+import static fj.data.List.cons;
 
 /**
  * Created by MarkPerry on 7/07/2014.
  */
 public final class State<S, A> {
 
-	private final F<S, P2<S, A>> run;
+  public static <S, A> State<S, A> unit(F<S, P2<S, A>> runF) {
+    return new State<>(s -> Trampoline.pure(runF.f(s)));
+  }
 
-	private State(F<S, P2<S, A>> f) {
-		run = f;
-	}
+  public static <S> State<S, S> init() {
+    return unit(s -> dup(s));
+  }
 
-	public P2<S, A> run(S s) {
-		return run.f(s);
-	}
+  public static <S> State<S, S> units(F<S, S> f) {
+    return unit(s -> dup(f.f(s)));
+  }
 
-	public static <S, A> State<S, A> unit(F<S, P2<S, A>> f) {
-		return new State<>(f);
-	}
+  private static <S> P2<S, S> dup(S s) {
+    return p(s, s);
+  }
 
-	public static <S> State<S, S> units(F<S, S> f) {
-		return unit((S s) -> {
-			S s2 = f.f(s);
-			return p(s2, s2);
-		});
-	}
+  public static <S, A> State<S, A> constant(A a) {
+    return unit(s -> p(s, a));
+  }
 
-	public static <S, A> State<S, A> constant(A a) {
-		return unit(s -> p(s, a));
-	}
+  public static <S, A> State<S, A> gets(F<S, A> f) {
+    return unit(s -> p(s, f.f(s)));
+  }
 
-	public <B> State<S, B> map(F<A, B> f) {
-		return unit((S s) -> {
-			P2<S, A> p2 = run(s);
-			B b = f.f(p2._2());
-			return p(p2._1(), b);
-		});
-	}
+  public static <S> State<S, Unit> put(S s) {
+    return unit(ignoredS -> p(s, Unit.unit()));
+  }
 
-	public static <S> State<S, Unit> modify(F<S, S> f) {
-		return State.<S>init().flatMap(s -> unit(s2 -> p(f.f(s), Unit.unit())));
-	}
+  public static <S> State<S, Unit> modify(F<S, S> f) {
+    return unit(s -> p(f.f(s), Unit.unit()));
+  }
 
-	public <B> State<S, B> mapState(F<P2<S, A>, P2<S, B>> f) {
-		return unit(s -> f.f(run(s)));
-	}
+  public static <S, A, B> State<S, B> flatMap(State<S, A> ts, F<A, State<S, B>> f) {
+    return ts.flatMap(f);
+  }
 
-	public static <S, B, C> State<S, C> flatMap(State<S, B> mb, F<B, State<S, C>> f) {
-		return mb.flatMap(f);
-	}
+  /**
+   * Evaluate each action in the sequence from left to right, and collect the results.
+   */
+  public static <S, A> State<S, List<A>> sequence(List<State<S, A>> list) {
+    return list
+        .foldLeft(
+            (acc, ts) -> acc.flatMap(as -> ts.map(a -> cons(a, as))),
+            State.<S, List<A>>constant(List.nil()))
+        .map(as -> as.reverse());
+  }
 
-	public <B> State<S, B> flatMap(F<A, State<S, B>> f) {
-		return unit((S s) -> {
-			P2<S, A> p = run(s);
-			A a = p._2();
-			S s2 = p._1();
-			State<S, B> smb = f.f(a);
-			return smb.run(s2);
-		});
-	}
+  /**
+   * Map each element of a structure to an action, evaluate these actions from left to right
+   * and collect the results.
+   */
+  public static <S, A, B> State<S, List<B>> traverse(List<A> list, F<A, State<S, B>> f) {
+    return list
+        .foldLeft(
+            (acc, a) -> acc.flatMap(bs -> f.f(a).map(b -> cons(b, bs))),
+            State.<S, List<B>>constant(List.nil()))
+        .map(bs -> bs.reverse());
+  }
 
-	public static <S> State<S, S> init() {
-		return unit(s -> p(s, s));
-	}
+  private static <S, A> State<S, A> suspended(F<S, Trampoline<P2<S, A>>> runF) {
+    return new State<>(s -> suspend(lazy(() -> runF.f(s))));
+  }
 
-	public State<S, S> gets() {
-		return unit(s -> {
-			P2<S, A> p = run(s);
-			S s2 = p._1();
-			return p(s2, s2);
-		});
-	}
+  private final F<S, Trampoline<P2<S, A>>> runF;
 
-	public static <S> State<S, Unit> put(S s) {
-		return unit((S z) -> p(s, Unit.unit()));
-	}
+  private State(F<S, Trampoline<P2<S, A>>> runF) {
+    this.runF = runF;
+  }
 
-	public A eval(S s) {
-		return run(s)._2();
-	}
+  public P2<S, A> run(S s) {
+    return runF.f(s).run();
+  }
 
-	public S exec(S s) {
-		return run(s)._1();
-	}
+  public A eval(S s) {
+    return run(s)._2();
+  }
 
-	public State<S, A> withs(F<S, S> f) {
-		return unit(F1Functions.andThen(f, run));
-	}
+  public S exec(S s) {
+    return run(s)._1();
+  }
 
-	public static <S, A> State<S, A> gets(F<S, A> f) {
-		return State.<S>init().map(f);
-	}
+  public State<S, S> gets() {
+    return mapState(result -> p(result._1(), result._1()));
+  }
 
-	/**
-	 * Evaluate each action in the sequence from left to right, and collect the results.
-	 */
-	public static <S, A> State<S, List<A>> sequence(List<State<S, A>> list) {
-		return list.foldLeft((State<S, List<A>> acc, State<S, A> ma) ->
-			acc.flatMap((List<A> xs) -> ma.map(xs::snoc)
-		), constant(List.nil()));
-	}
+  public <B> State<S, B> map(F<A, B> f) {
+    return mapState(result -> p(result._1(), f.f(result._2())));
+  }
 
-	/**
-	 * Map each element of a structure to an action, evaluate these actions from left to right
-	 * and collect the results.
-	 */
-	public static <S, A, B> State<S, List<B>> traverse(List<A> list, F<A, State<S, B>> f) {
-		return list.foldLeft((State<S, List<B>> acc, A a) ->
-			acc.flatMap(bs -> f.f(a).map(bs::snoc)
-		), constant(List.nil()));
-	}
+  public <B> State<S, B> mapState(F<P2<S, A>, P2<S, B>> f) {
+    return suspended(s -> runF.f(s).map(result -> f.f(result)));
+  }
+
+  public State<S, A> withs(F<S, S> f) {
+    return suspended(s -> runF.f(f.f(s)));
+  }
+
+  public <B> State<S, B> flatMap(F<A, State<S, B>> f) {
+    return suspended(s -> runF.f(s).bind(result -> Trampoline.pure(f.f(result._2()).run(result._1()))));
+  }
 
 }

--- a/props-core/src/test/java/fj/data/StateProperties.java
+++ b/props-core/src/test/java/fj/data/StateProperties.java
@@ -1,0 +1,409 @@
+package fj.data;
+
+import fj.F;
+import fj.P2;
+import fj.Unit;
+import fj.test.Arbitrary;
+import fj.test.Coarbitrary;
+import fj.test.Gen;
+import fj.test.Property;
+import fj.test.reflect.CheckParams;
+import fj.test.runner.PropertyTestRunner;
+import org.junit.runner.RunWith;
+
+import static fj.P.p;
+import static fj.data.List.range;
+import static fj.test.Arbitrary.arbF;
+import static fj.test.Arbitrary.arbInteger;
+import static fj.test.Arbitrary.arbList;
+import static fj.test.Arbitrary.arbP2;
+import static fj.test.Arbitrary.arbitrary;
+import static fj.test.Coarbitrary.coarbInteger;
+import static fj.test.Coarbitrary.coarbP2;
+import static fj.test.Property.prop;
+import static fj.test.Property.property;
+
+@RunWith(PropertyTestRunner.class)
+public final class StateProperties {
+
+  public Property unit() {
+    return property(
+        arbRunF(coarbInteger, arbInteger, arbInteger),
+        arbInteger,
+        (runF, initS) -> prop(testUnit(runF, initS)));
+  }
+
+  private static <S, A> boolean testUnit(F<S, P2<S, A>> runF, S initS) {
+    State<S, A> instance = State.unit(runF);
+    P2<S, A> actual = instance.run(initS);
+    P2<S, A> expected = runF.f(initS);
+    return actual.equals(expected);
+  }
+
+  public Property init() {
+    return property(
+        arbInteger,
+        initS -> prop(testInit(initS)));
+  }
+
+  private static <S> boolean testInit(S initS) {
+    State<S, S> instance = State.init();
+    P2<S, S> actual = instance.run(initS);
+    P2<S, S> expected = p(initS, initS);
+    return actual.equals(expected);
+  }
+
+  public Property units() {
+    return property(
+        arbF(coarbInteger, arbInteger),
+        arbInteger,
+        (f, initS) -> prop(testUnits(f, initS)));
+  }
+
+  private static <S> boolean testUnits(F<S, S> f, S initS) {
+    State<S, S> instance = State.units(f);
+    P2<S, S> actual = instance.run(initS);
+    S expectedS = f.f(initS);
+    P2<S, S> expected = p(expectedS, expectedS);
+    return actual.equals(expected);
+  }
+
+  public Property constant() {
+    return property(
+        arbInteger,
+        arbInteger,
+        (a, initS) -> prop(testConstant(a, initS)));
+  }
+
+  private static <S, A> boolean testConstant(A a, S initS) {
+    State<S, A> instance = State.constant(a);
+    P2<S, A> actual = instance.run(initS);
+    P2<S, A> expected = p(initS, a);
+    return actual.equals(expected);
+  }
+
+  public Property staticGets() {
+    return property(
+        arbF(coarbInteger, arbInteger),
+        arbInteger,
+        (f, initS) -> prop(testStaticGets(f, initS)));
+  }
+
+  private static <S, A> boolean testStaticGets(F<S, A> f, S initS) {
+    State<S, A> instance = State.gets(f);
+    P2<S, A> actual = instance.run(initS);
+    P2<S, A> expected = p(initS, f.f(initS));
+    return actual.equals(expected);
+  }
+
+  public Property put() {
+    return property(
+        arbInteger,
+        arbInteger,
+        (newS, initS) -> prop(testPut(newS, initS)));
+  }
+
+  private static <S> boolean testPut(S newS, S initS) {
+    State<S, Unit> instance = State.put(newS);
+    P2<S, Unit> actual = instance.run(initS);
+    P2<S, Unit> expected = p(newS, Unit.unit());
+    return actual.equals(expected);
+  }
+
+  public Property modify() {
+    return property(
+        arbF(coarbInteger, arbInteger),
+        arbInteger,
+        (f, initS) -> prop(testModify(f, initS)));
+  }
+
+  private static <S> boolean testModify(F<S, S> f, S initS) {
+    State<S, Unit> instance = State.modify(f);
+    P2<S, Unit> actual = instance.run(initS);
+    P2<S, Unit> expected = p(f.f(initS), Unit.unit());
+    return actual.equals(expected);
+  }
+
+  public Property staticFlatMap() {
+    return property(
+        arbRunF(coarbInteger, arbInteger, arbInteger),
+        arbF(coarbInteger, arbState(coarbInteger, arbInteger, arbInteger)),
+        arbInteger,
+        (runF, f, initS) -> prop(testStaticFlatMap(runF, f, initS)));
+  }
+
+  private static <S, A, B> boolean testStaticFlatMap(F<S, P2<S, A>> runF, F<A, State<S, B>> f, S initS) {
+    State<S, B> instance = State.flatMap(State.unit(runF), f);
+    P2<S, B> actual = instance.run(initS);
+    P2<S, A> intermediateExpected = runF.f(initS);
+    P2<S, B> expected = f.f(intermediateExpected._2()).run(intermediateExpected._1());
+    return actual.equals(expected);
+  }
+
+  public Property sequence() {
+    return property(
+        arbList(arbState(coarbInteger, arbInteger, arbInteger)),
+        arbInteger,
+        (states, initS) -> prop(testSequence(states, initS)));
+  }
+
+  private static <S, A> boolean testSequence(List<State<S, A>> states, S initS) {
+    State<S, List<A>> instance = State.sequence(states);
+    P2<S, List<A>> actual = instance.run(initS);
+
+    S expectedFinalS = initS;
+    List<A> expectedAs = List.nil();
+    List<State<S, A>> remainingStates = states;
+    while (remainingStates.isNotEmpty()) {
+      P2<S, A> nextResult = remainingStates.head().run(expectedFinalS);
+      expectedFinalS = nextResult._1();
+      expectedAs = List.cons(nextResult._2(), expectedAs);
+      remainingStates = remainingStates.tail();
+    }
+    expectedAs = expectedAs.reverse();
+
+    P2<S, List<A>> expected = p(expectedFinalS, expectedAs);
+    return actual.equals(expected);
+  }
+
+  public Property traverse() {
+    return property(
+        arbList(arbInteger),
+        arbF(coarbInteger, arbState(coarbInteger, arbInteger, arbInteger)),
+        arbInteger,
+        (as, f, initS) -> prop(testTraverse(as, f, initS)));
+
+  }
+
+  private static <S, A, B> boolean testTraverse(List<A> as, F<A, State<S, B>> f, S initS) {
+    State<S, List<B>> instance = State.traverse(as, f);
+    P2<S, List<B>> actual = instance.run(initS);
+
+    S expectedFinalS = initS;
+    List<B> expectedFinalBs = List.nil();
+    List<A> currAs = as;
+    while (currAs.isNotEmpty()) {
+      P2<S, B> nextStateAndB = f.f(currAs.head()).run(expectedFinalS);
+      expectedFinalS = nextStateAndB._1();
+      expectedFinalBs = List.cons(nextStateAndB._2(), expectedFinalBs);
+      currAs = currAs.tail();
+    }
+    expectedFinalBs = expectedFinalBs.reverse();
+    P2<S, List<B>> expected = p(expectedFinalS, expectedFinalBs);
+
+    return actual.equals(expected);
+  }
+
+  public Property run() {
+    return property(
+        arbRunF(coarbInteger, arbInteger, arbInteger),
+        arbInteger,
+        (runF, initS) -> prop(testRun(runF, initS)));
+  }
+
+  private static <S, A> boolean testRun(F<S, P2<S, A>> runF, S initS) {
+    State<S, A> instance = State.unit(runF);
+    P2<S, A> actual = instance.run(initS);
+    P2<S, A> expected = runF.f(initS);
+    return actual.equals(expected);
+  }
+
+  public Property eval() {
+    return property(
+        arbRunF(coarbInteger, arbInteger, arbInteger),
+        arbInteger,
+        (runF, initS) -> prop(testEval(runF, initS)));
+  }
+
+  private static <S, A> boolean testEval(F<S, P2<S, A>> runF, S initS) {
+    State<S, A> instance = State.unit(runF);
+    A actual = instance.eval(initS);
+    A expected = runF.f(initS)._2();
+    return actual.equals(expected);
+  }
+
+  public Property exec() {
+    return property(
+        arbRunF(coarbInteger, arbInteger, arbUnit),
+        arbInteger,
+        (runF, initS) -> prop(testExec(runF, initS)));
+  }
+
+  private static <S> boolean testExec(F<S, P2<S, Unit>> runF, S initS) {
+    State<S, Unit> instance = State.unit(runF);
+    S actual = instance.exec(initS);
+    S expected = runF.f(initS)._1();
+    return actual.equals(expected);
+  }
+
+  public Property getsProperty() {
+    return property(
+        arbState(coarbInteger, arbInteger, arbInteger),
+        arbInteger,
+        (state, initS) -> prop(testGets(state, initS)));
+  }
+
+  private static <S, A> boolean testGets(State<S, A> state, S initS) {
+    State<S, S> instance = state.gets();
+    P2<S, S> actual = instance.run(initS);
+    P2<S, S> expected = p(state.run(initS)._1(), state.run(initS)._1());
+    return actual.equals(expected);
+  }
+
+  public Property map() {
+    return property(
+        arbState(coarbInteger, arbInteger, arbInteger),
+        arbF(coarbInteger, arbInteger),
+        arbInteger,
+        (state, f, initS) -> prop(testMap(state, f, initS)));
+  }
+
+  private static <S, A, B> boolean testMap(State<S, A> state, F<A, B> f, S initS) {
+    State<S, B> instance = state.map(f);
+    P2<S, B> actual = instance.run(initS);
+    P2<S, B> expected = state.run(initS).map2(f);
+    return actual.equals(expected);
+  }
+
+  public Property mapState() {
+    return property(
+        arbState(coarbInteger, arbInteger, arbInteger),
+        arbMapStateF(coarbInteger, coarbInteger, arbInteger, arbInteger),
+        arbInteger,
+        (state, f, initS) -> prop(testMapState(state, f, initS)));
+  }
+
+  private static <S, A, B> boolean testMapState(State<S, A> state, F<P2<S, A>, P2<S, B>> f, S initS) {
+    State<S, B> instance = state.mapState(f);
+    P2<S, B> actual = instance.run(initS);
+    P2<S, B> expected = f.f(state.run(initS));
+    return actual.equals(expected);
+  }
+
+  public Property withs() {
+    return property(
+        arbState(coarbInteger, arbInteger, arbInteger),
+        arbF(coarbInteger, arbInteger),
+        arbInteger,
+        (state, f, initS) -> prop(testWiths(state, f, initS)));
+  }
+
+  private static <S, A> boolean testWiths(State<S, A> state, F<S, S> f, S initS) {
+    State<S, A> instance = state.withs(f);
+    P2<S, A> actual = instance.run(initS);
+    P2<S, A> expected = state.run(f.f(initS));
+    return actual.equals(expected);
+  }
+
+  public Property flatMap() {
+    return property(
+        arbState(coarbInteger, arbInteger, arbInteger),
+        arbF(coarbInteger, arbState(coarbInteger, arbInteger, arbInteger)),
+        arbInteger,
+        (state, f, initS) -> prop(testFlatMap(state, f, initS)));
+  }
+
+  private static <S, A, B> boolean testFlatMap(State<S, A> state, F<A, State<S, B>> f, S initS) {
+    State<S, B> instance = state.flatMap(f);
+    P2<S, B> actual = instance.run(initS);
+    P2<S, B> expected = f.f(state.run(initS)._2()).run(state.run(initS)._1());
+    return actual.equals(expected);
+  }
+
+  @CheckParams(minSuccessful = 1)
+  public Property getsStackSafety() {
+    return property(
+        arbHugeState(
+            arbState(coarbInteger, arbInteger, arbInteger),
+            currState -> arbitrary(Gen.value(currState.gets()))),
+        arbInteger,
+        (instance, initS) -> prop(testNoStackOverflow(instance, initS)));
+  }
+
+  @CheckParams(minSuccessful = 1)
+  public Property mapStackSafety() {
+    return property(
+        arbHugeState(
+            arbState(coarbInteger, arbInteger, arbInteger),
+            currState -> arbitrary(Gen.gen(s -> r -> currState.map(arbF(coarbInteger, arbInteger).gen.gen(s, r))))),
+        arbInteger,
+        (instance, initS) -> prop(testNoStackOverflow(instance, initS)));
+  }
+
+  @CheckParams(minSuccessful = 1)
+  public Property mapStateStackSafety() {
+    return property(
+        arbHugeState(
+            arbState(coarbInteger, arbInteger, arbInteger),
+            currState -> arbitrary(Gen.gen(s -> r ->
+                currState.mapState(arbMapStateF(coarbInteger, coarbInteger, arbInteger, arbInteger).gen.gen(s, r))))),
+        arbInteger,
+        (instance, initS) -> prop(testNoStackOverflow(instance, initS)));
+  }
+
+  @CheckParams(minSuccessful = 1)
+  public Property withsStackSafety() {
+    return property(
+        arbHugeState(
+            arbState(coarbInteger, arbInteger, arbInteger),
+            currState -> arbitrary(Gen.gen(s -> r -> currState.withs(arbF(coarbInteger, arbInteger).gen.gen(s, r))))),
+        arbInteger,
+        (instance, initS) -> prop(testNoStackOverflow(instance, initS)));
+  }
+
+  @CheckParams(minSuccessful = 1)
+  public Property flatMapStackSafety() {
+    return property(
+        arbHugeState(
+            arbState(coarbInteger, arbInteger, arbInteger),
+            currState -> arbitrary(Gen.gen(s -> r ->
+                currState.flatMap(arbF(coarbInteger, arbState(coarbInteger, arbInteger, arbInteger)).gen.gen(s, r))))),
+        arbInteger,
+        (instance, initS) -> prop(testNoStackOverflow(instance, initS)));
+  }
+
+  private static <S, A> boolean testNoStackOverflow(State<S, A> instance, S initS) {
+    instance.run(initS);
+    return true;
+  }
+
+  private static final Arbitrary<Unit> arbUnit = arbitrary(Gen.value(Unit.unit()));
+
+  private static <S, A> Arbitrary<F<S, P2<S, A>>> arbRunF(
+      Coarbitrary<S> coarbInitS,
+      Arbitrary<S> arbNextS,
+      Arbitrary<A> arbValue) {
+
+    return arbF(coarbInitS, arbP2(arbNextS, arbValue));
+  }
+
+  private static <S, A> Arbitrary<F<P2<S, A>, P2<S, A>>> arbMapStateF(
+      Coarbitrary<S> coarbInitS,
+      Coarbitrary<A> coarbInitValue,
+      Arbitrary<S> arbNextS,
+      Arbitrary<A> arbNextValue) {
+
+    return arbF(coarbP2(coarbInitS, coarbInitValue), arbP2(arbNextS, arbNextValue));
+  }
+
+  private static <S, A> Arbitrary<State<S, A>> arbState(
+      Coarbitrary<S> coarbInitS,
+      Arbitrary<S> arbNextS,
+      Arbitrary<A> arbValue) {
+
+    Arbitrary<F<S, P2<S, A>>> arbRunF = arbRunF(coarbInitS, arbNextS, arbValue);
+    return arbitrary(Gen.gen(s -> r -> State.unit(arbRunF.gen.gen(s, r))));
+  }
+
+  private static final int HUGE_SIZE = 10000;
+
+  private static <S, A> Arbitrary<State<S, A>> arbHugeState(
+      Arbitrary<State<S, A>> arbInitState,
+      F<State<S, A>, Arbitrary<State<S, A>>> nextArbStateF) {
+
+    return arbitrary(Gen.gen(s -> r -> range(0, HUGE_SIZE).foldLeft(
+        (acc, x) -> nextArbStateF.f(acc).gen.gen(s, r),
+        arbInitState.gen.gen(s, r))));
+  }
+
+}


### PR DESCRIPTION
A rebased version of #270.
original PR comment by @mrbackend:
> Issue #259.

> As the original file was TAB-indented, and it is my understanding that we generally use SPACE indentation, such that every single line would be marked as changed anyway, I took the liberty to reorganize the functions in a way that feels more structured, at least to me. Almost every function body is touched anyway.

> And, even though the State Monad is well known among FP-ers, I think I should add some more Javadoc.
