### PR TITLE
Switched the the Gen and Shrink implementations for Natural to use Bi…

### DIFF
--- a/quickcheck/src/main/java/fj/test/Arbitrary.java
+++ b/quickcheck/src/main/java/fj/test/Arbitrary.java
@@ -476,12 +476,6 @@ public final class Arbitrary {
   });
 
   /**
-   * An arbitrary implementation for naturals.
-   */
-  public static final Gen<Natural> arbNatural = arbLong.filter(not(longEqual.eq(Long.MIN_VALUE)))
-      .map(Longs.abs).map(Natural::natural).map(o -> o.some());
-
-  /**
    * An arbitrary implementation for character values.
    */
   public static final Gen<Character> arbCharacter = choose(0, 65536).map(i -> (char) i.intValue());
@@ -1178,6 +1172,11 @@ public final class Arbitrary {
       arbBigInteger.map(BigDecimal::new);
 
   // END java.math
+
+  /**
+   * An arbitrary implementation for naturals.
+   */
+  public static final Gen<Natural> arbNatural = arbBigInteger.map(BigInteger::abs).map(Natural::natural).map(o -> o.some());
 
   /**
    * An arbitrary implementation for locales.

--- a/quickcheck/src/main/java/fj/test/Shrink.java
+++ b/quickcheck/src/main/java/fj/test/Shrink.java
@@ -184,10 +184,6 @@ public final class Shrink<A> {
    */
   public static final Shrink<Double> shrinkDouble = shrinkLong.map(Long_Double, Double_Long);
 
-  /**
-   * A shrink strategy for naturals.
-   */
-  public static final Shrink<Natural> shrinkNatural = shrinkLong.map(l -> Natural.natural(l).orSome(Natural.ZERO), Natural::longValue);
 
   /**
    * Returns a shrink strategy for optional values. A 'no value' is already fully
@@ -700,6 +696,12 @@ public final class Shrink<A> {
       shrinkBigInteger.map(BigDecimal::new, BigDecimal::toBigInteger);
 
   // END java.math
+
+  /**
+   * A shrink strategy for naturals.
+   */
+  public static final Shrink<Natural> shrinkNatural = shrinkBigInteger.map(l -> Natural.natural(l).orSome(Natural.ZERO), Natural::bigIntegerValue);
+
 
   /**
    * Returns a shrinking strategy for product-1 values.


### PR DESCRIPTION
…gInteger instead of Long. This will allow for generation of Naturals that are larger than Long.MAX_VALUE.  The implementations had to be moved within their respective classes to avoid forward reference compilation errors.  These changes build off of  #274 and #277.