### PR TITLE
deprecate List#groupBy that take an implicit ordering...

### DIFF
--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -1299,13 +1299,16 @@ public abstract class List<A> implements Iterable<A> {
 
   /**
    * Groups the elements of this list by a given keyFunction into a {@link TreeMap}.
-   * The ordering of the keys is determined by {@link fj.Ord#hashOrd()}.
+   * The ordering of the keys is determined by {@link fj.Ord#hashEqualsOrd()} (ie. Object#hasCode/equals).
+   * This is not safe and therefore this method is now deprecated.
    *
    * @param keyFunction The function to select the keys for the map.
    * @return A TreeMap containing the keys with the accumulated list of matched elements.
+   *
+   * @deprecated As of release 4.7, use {@link #groupBy(F, Ord)}
    */
   public final <B> TreeMap<B, List<A>> groupBy(final F<A, B> keyFunction) {
-    return groupBy(keyFunction, Ord.hashOrd());
+    return groupBy(keyFunction, Ord.hashEqualsOrd());
   }
 
   /**

--- a/demo/src/main/java/fj/demo/List_groupBy.java
+++ b/demo/src/main/java/fj/demo/List_groupBy.java
@@ -18,7 +18,7 @@ public final class List_groupBy {
   private static void keyDemo() {
     System.out.println("KeyDemo");
     final List<String> words = list("Hello", "World", "how", "are", "your", "doing");
-    final TreeMap<Integer, List<String>> lengthMap = words.groupBy(String::length);
+    final TreeMap<Integer, List<String>> lengthMap = words.groupBy(String::length, Ord.intOrd);
 
     lengthMap.forEach(entry -> System.out.println(String.format("Words with %d chars: %s", entry._1(), entry._2())));
   }

--- a/props-core-scalacheck/src/test/scala/fj/data/CheckList.scala
+++ b/props-core-scalacheck/src/test/scala/fj/data/CheckList.scala
@@ -187,7 +187,7 @@ object CheckList extends Properties("List") {
       join(a)))
 
   property("groupBy") = forAll((a: List[Int]) => {
-    val result = a.groupBy((x: Int) => (x % 2 == 0): lang.Boolean)
+    val result = a.groupBy((x: Int) => (x % 2 == 0): lang.Boolean, Ord.booleanOrd)
     result.get(true).forall((xs: List[Int]) => xs.forall((x: Int) => (x % 2 == 0): lang.Boolean): lang.Boolean) &&
       result.get(false).forall((xs: List[Int]) => xs.forall((x: Int) => (x % 2 != 0): lang.Boolean): lang.Boolean) &&
       a.map((x: Int) => (x % 2) == 0: lang.Boolean).nub().length() == result.size()

--- a/props-core/src/test/java/fj/data/properties/ListProperties.java
+++ b/props-core/src/test/java/fj/data/properties/ListProperties.java
@@ -255,7 +255,7 @@ public class ListProperties {
 
   public Property groupBy() {
     return property(arbList(arbInteger), list -> {
-      final TreeMap<Boolean, List<Integer>> map = list.groupBy(i -> i % 2 == 0);
+      final TreeMap<Boolean, List<Integer>> map = list.groupBy(i -> i % 2 == 0, Ord.booleanOrd);
       final List<Integer> list1 = map.get(true).orSome(nil());
       final List<Integer> list2 = map.get(false).orSome(nil());
       return prop(list.length() == list1.length() + list2.length())


### PR DESCRIPTION
based on Object#hashCode.
Also replaced implementation to use the slightly better Ord#hashEqualsOrd.