### PR TITLE
Fix #287: Add semigroup constraint to List.traverseValidation

### DIFF
--- a/core/src/main/java/fj/data/List.java
+++ b/core/src/main/java/fj/data/List.java
@@ -10,6 +10,7 @@ import fj.Ord;
 import fj.Ordering;
 import fj.P;
 import fj.P1;
+import fj.Semigroup;
 import fj.Show;
 import fj.Unit;
 import fj.P2;
@@ -676,10 +677,8 @@ public abstract class List<A> implements Iterable<A> {
         single(List.nil()));
   }
 
-  public final <E, B> Validation<E, List<B>> traverseValidation(final F<A, Validation<E, B>> f) {
-    return foldRight(
-        (a, acc) -> f.f(a).bind(b -> acc.map(bs -> bs.cons(b))),
-        Validation.success(List.nil()));
+  public final <E, B> Validation<E, List<B>> traverseValidation(Semigroup<E> s, final F<A, Validation<E, B>> f) {
+    return Validation.sequence(s, map(f));
   }
 
   public final <B> V2<List<B>> traverseV2(final F<A, V2<B>> f) {
@@ -2166,8 +2165,8 @@ public abstract class List<A> implements Iterable<A> {
         }
 
         @Override
-        public <E> F<List<A>, Validation<E, List<B>>> modifyValidationF(F<A, Validation<E, B>> f) {
-          return l -> l.traverseValidation(f);
+        public <E> F<List<A>, Validation<E, List<B>>> modifyValidationF(Semigroup<E> s, F<A, Validation<E, B>> f) {
+          return l -> l.traverseValidation(s, f);
         }
 
         @Override

--- a/core/src/main/java/fj/data/optic/PIso.java
+++ b/core/src/main/java/fj/data/optic/PIso.java
@@ -6,6 +6,7 @@ import fj.Monoid;
 import fj.P;
 import fj.P1;
 import fj.P2;
+import fj.Semigroup;
 import fj.control.Trampoline;
 import fj.control.parallel.Promise;
 import fj.data.Either;
@@ -314,7 +315,7 @@ public abstract class PIso<S, T, A, B> {
       }
 
       @Override
-      public <E> F<S, Validation<E, T>> modifyValidationF(final F<A, Validation<E, B>> f) {
+      public <E> F<S, Validation<E, T>> modifyValidationF(Semigroup<E> s, final F<A, Validation<E, B>> f) {
         return self.modifyValidationF(f);
       }
 

--- a/core/src/main/java/fj/data/optic/PLens.java
+++ b/core/src/main/java/fj/data/optic/PLens.java
@@ -4,6 +4,7 @@ import fj.F;
 import fj.Function;
 import fj.Monoid;
 import fj.P1;
+import fj.Semigroup;
 import fj.control.Trampoline;
 import fj.control.parallel.Promise;
 import fj.data.Either;
@@ -320,7 +321,7 @@ public abstract class PLens<S, T, A, B> {
       }
 
       @Override
-      public <E> F<S, Validation<E, T>> modifyValidationF(final F<A, Validation<E, B>> f) {
+      public <E> F<S, Validation<E, T>> modifyValidationF(Semigroup<E> s, final F<A, Validation<E, B>> f) {
         return self.modifyValidationF(f);
       }
 

--- a/core/src/main/java/fj/data/optic/POptional.java
+++ b/core/src/main/java/fj/data/optic/POptional.java
@@ -6,6 +6,7 @@ import fj.Monoid;
 import fj.P;
 import fj.P1;
 import fj.P2;
+import fj.Semigroup;
 import fj.control.Trampoline;
 import fj.control.parallel.Promise;
 import fj.control.parallel.Strategy;
@@ -345,7 +346,7 @@ public abstract class POptional<S, T, A, B> {
       }
 
       @Override
-      public <E> F<S, Validation<E, T>> modifyValidationF(final F<A, Validation<E, B>> f) {
+      public <E> F<S, Validation<E, T>> modifyValidationF(Semigroup<E> s, final F<A, Validation<E, B>> f) {
         return self.modifyValidationF(f);
       }
 

--- a/core/src/main/java/fj/data/optic/PPrism.java
+++ b/core/src/main/java/fj/data/optic/PPrism.java
@@ -5,6 +5,7 @@ import fj.Function;
 import fj.Monoid;
 import fj.P;
 import fj.P1;
+import fj.Semigroup;
 import fj.control.Trampoline;
 import fj.control.parallel.Promise;
 import fj.control.parallel.Strategy;
@@ -310,7 +311,7 @@ public abstract class PPrism<S, T, A, B> {
       }
 
       @Override
-      public <E> F<S, Validation<E, T>> modifyValidationF(final F<A, Validation<E, B>> f) {
+      public <E> F<S, Validation<E, T>> modifyValidationF(Semigroup<E> s, final F<A, Validation<E, B>> f) {
         return self.modifyValidationF(f);
       }
 

--- a/core/src/main/java/fj/data/optic/Traversal.java
+++ b/core/src/main/java/fj/data/optic/Traversal.java
@@ -8,6 +8,7 @@ import fj.F6;
 import fj.F7;
 import fj.Monoid;
 import fj.P1;
+import fj.Semigroup;
 import fj.control.Trampoline;
 import fj.control.parallel.Promise;
 import fj.data.Either;
@@ -72,8 +73,8 @@ public final class Traversal<S, A> extends PTraversal<S, S, A, A> {
   }
 
   @Override
-  public <E> F<S, Validation<E, S>> modifyValidationF(final F<A, Validation<E, A>> f) {
-    return pTraversal.modifyValidationF(f);
+  public <E> F<S, Validation<E, S>> modifyValidationF(Semigroup<E> s, final F<A, Validation<E, A>> f) {
+    return pTraversal.modifyValidationF(s, f);
   }
 
   @Override


### PR DESCRIPTION
for now implement traverse from sequence.
 (but the other way around would be better)