### PR TITLE
Introduce Sum-types

### DIFF
--- a/core/src/main/java/fj/Function.java
+++ b/core/src/main/java/fj/Function.java
@@ -863,4 +863,38 @@ public final class Function {
       final F<A, F<B, F<C, F<D, F<E, F<F$, F<G, F<H, I>>>>>>>> f, final H h) {
     return a -> b -> c -> d -> e -> f$ -> g -> uncurryF8(f).f(a, b, c, d, e, f$, g, h);
   }
+
+  /**
+   * Unite functions into a function on a sum-type.
+   */
+  public static <result, _1, _2> F<S2<_1, _2>, result> sum(
+    F<_1, result> projection1,
+    F<_2, result> projection2
+  ) {
+    return s -> s.match(projection1, projection2);
+  }
+
+  /**
+   * Unite functions into a function on a sum-type.
+   */
+  public static <result, _1, _2, _3> F<S3<_1, _2, _3>, result> sum(
+    F<_1, result> projection1,
+    F<_2, result> projection2,
+    F<_3, result> projection3
+  ) {
+    return s -> s.match(projection1, projection2, projection3);
+  }
+
+  /**
+   * Unite functions into a function on a sum-type.
+   */
+  public static <result, _1, _2, _3, _4> F<S4<_1, _2, _3, _4>, result> sum(
+    F<_1, result> projection1,
+    F<_2, result> projection2,
+    F<_3, result> projection3,
+    F<_4, result> projection4
+  ) {
+    return s -> s.match(projection1, projection2, projection3, projection4);
+  }
+
 }

--- a/core/src/main/java/fj/S2.java
+++ b/core/src/main/java/fj/S2.java
@@ -1,0 +1,45 @@
+package fj;
+
+import fj.data.Option;
+
+/**
+ * A sum-type with 2 alternatives.
+ */
+public final class S2<_1, _2> {
+
+  private final int tag;
+  private final Object value;
+
+  private S2(int tag, Object value) {
+    this.tag = tag;
+    this.value = value;
+  }
+
+  public static <_1, _2> S2<_1, _2> _1(_1 value) {
+    return new S2<_1, _2>(1, value);
+  }
+
+  public static <_1, _2> S2<_1, _2> _2(_2 value) {
+    return new S2<_1, _2>(2, value);
+  }
+
+  public Option<_1> _1() {
+    return tag == 1 ? Option.some((_1) value) : Option.none();
+  }
+
+  public Option<_2> _2() {
+    return tag == 2 ? Option.some((_2) value) : Option.none();
+  }
+
+  public <result, _1, _2> result match(F<_1, result> projection1, F<_2, result> projection2) {
+    switch (tag) {
+      case 1:
+        return projection1.f((_1) value);
+      case 2:
+        return projection2.f((_2) value);
+      default:
+        throw new Error();
+    }
+  }
+
+}

--- a/core/src/main/java/fj/S3.java
+++ b/core/src/main/java/fj/S3.java
@@ -1,0 +1,55 @@
+package fj;
+
+import fj.data.Option;
+
+/**
+ * A sum-type with 3 alternatives.
+ */
+public final class S3<_1, _2, _3> {
+
+  private final int tag;
+  private final Object value;
+
+  private S3(int tag, Object value) {
+    this.tag = tag;
+    this.value = value;
+  }
+
+  public static <_1, _2, _3> S3<_1, _2, _3> _1(_1 value) {
+    return new S3<_1, _2, _3>(1, value);
+  }
+
+  public static <_1, _2, _3> S3<_1, _2, _3> _2(_2 value) {
+    return new S3<_1, _2, _3>(2, value);
+  }
+
+  public static <_1, _2, _3> S3<_1, _2, _3> _3(_3 value) {
+    return new S3<_1, _2, _3>(3, value);
+  }
+
+  public Option<_1> _1() {
+    return tag == 1 ? Option.some((_1) value) : Option.none();
+  }
+
+  public Option<_2> _2() {
+    return tag == 2 ? Option.some((_2) value) : Option.none();
+  }
+
+  public Option<_3> _3() {
+    return tag == 3 ? Option.some((_3) value) : Option.none();
+  }
+
+  public <result, _1, _2, _3> result match(F<_1, result> projection1, F<_2, result> projection2, F<_3, result> projection3) {
+    switch (tag) {
+      case 1:
+        return projection1.f((_1) value);
+      case 2:
+        return projection2.f((_2) value);
+      case 3:
+        return projection3.f((_3) value);
+      default:
+        throw new Error();
+    }
+  }
+
+}

--- a/core/src/main/java/fj/S4.java
+++ b/core/src/main/java/fj/S4.java
@@ -1,0 +1,65 @@
+package fj;
+
+import fj.data.Option;
+
+/**
+ * A sum-type with 4 alternatives.
+ */
+public final class S4<_1, _2, _3, _4> {
+
+  private final int tag;
+  private final Object value;
+
+  private S4(int tag, Object value) {
+    this.tag = tag;
+    this.value = value;
+  }
+
+  public static <_1, _2, _3, _4> S4<_1, _2, _3, _4> _1(_1 value) {
+    return new S4<_1, _2, _3, _4>(1, value);
+  }
+
+  public static <_1, _2, _3, _4> S4<_1, _2, _3, _4> _2(_2 value) {
+    return new S4<_1, _2, _3, _4>(2, value);
+  }
+
+  public static <_1, _2, _3, _4> S4<_1, _2, _3, _4> _3(_3 value) {
+    return new S4<_1, _2, _3, _4>(3, value);
+  }
+
+  public static <_1, _2, _3, _4> S4<_1, _2, _3, _4> _4(_4 value) {
+    return new S4<_1, _2, _3, _4>(4, value);
+  }
+
+  public Option<_1> _1() {
+    return tag == 1 ? Option.some((_1) value) : Option.none();
+  }
+
+  public Option<_2> _2() {
+    return tag == 2 ? Option.some((_2) value) : Option.none();
+  }
+
+  public Option<_3> _3() {
+    return tag == 3 ? Option.some((_3) value) : Option.none();
+  }
+
+  public Option<_4> _4() {
+    return tag == 4 ? Option.some((_4) value) : Option.none();
+  }
+
+  public <result, _1, _2, _3, _4> result match(F<_1, result> projection1, F<_2, result> projection2, F<_3, result> projection3, F<_4, result> projection4) {
+    switch (tag) {
+      case 1:
+        return projection1.f((_1) value);
+      case 2:
+        return projection2.f((_2) value);
+      case 3:
+        return projection3.f((_3) value);
+      case 4:
+        return projection4.f((_4) value);
+      default:
+        throw new Error();
+    }
+  }
+
+}


### PR DESCRIPTION
This PR introduces Sum Types of different arities. Sum Type is a dual of Product Type, so since the library already has the Product types, it is natural to expect the Sum types as well.

The implementation is only a sketch so far, but I feel it should be a good basis for the full-blown integration.

For more info about Sum Types, see https://en.wikipedia.org/wiki/Tagged_union.
