### PR TITLE
Faster TreeMap.get

### DIFF
--- a/core/src/main/java/fj/data/Set.java
+++ b/core/src/main/java/fj/data/Set.java
@@ -516,6 +516,129 @@ public abstract class Set<A> implements Iterable<A> {
   }
 
   /**
+   * Find element equal to the given one.
+   *
+   * @param a An element to compare with.
+   * @return Some element in this set equal to the given one, or None.
+   */
+  public final Option<A> lookup(final A a) {
+    Set<A> s = this;
+    while (true)
+      if (s.isEmpty())
+        return none();
+      else {
+        final A h = s.head();
+        final Ordering i = ord.compare(a, h);
+        if (i == LT)
+          s = s.l();
+        else if (i == GT)
+          s = s.r();
+        else
+          return some(h);
+      }
+  }
+
+  /**
+   * Find largest element smaller than the given one.
+   *
+   * @param a An element to compare with.
+   * @return Some largest element in this set smaller than the given one, or None.
+   */
+  public final Option<A> lookupLT(final A a) {
+    Set<A> s = this;
+    Option<A> r = none();
+    while (true)
+      if (s.isEmpty())
+        return r;
+      else {
+        final A h = s.head();
+        final Ordering i = ord.compare(a, h);
+        if (i == GT) {
+          r = some(h);
+          s = s.r();
+        }
+        else
+          s = s.l();
+      }
+  }
+
+  /**
+   * Find smallest element greater than the given one.
+   *
+   * @param a An element to compare with.
+   * @return Some smallest element in this set greater than the given one, or None.
+   */
+  public final Option<A> lookupGT(final A a) {
+    Set<A> s = this;
+    Option<A> r = none();
+    while (true)
+      if (s.isEmpty())
+        return r;
+      else {
+        final A h = s.head();
+        final Ordering i = ord.compare(a, h);
+        if (i == LT) {
+          r = some(h);
+          s = s.l();
+        }
+        else
+          s = s.r();
+      }
+  }
+
+  /**
+   * Find largest element smaller or equal to the given one.
+   *
+   * @param a An element to compare with.
+   * @return Some largest element in this set smaller or equal to the given one, or None.
+   */
+  public final Option<A> lookupLE(final A a) {
+    Set<A> s = this;
+    Option<A> r = none();
+    while (true)
+      if (s.isEmpty())
+        return r;
+      else {
+        final A h = s.head();
+        final Ordering i = ord.compare(a, h);
+        if (i == LT)
+          s = s.l();
+        else if (i == GT) {
+          r = some(h);
+          s = s.r();
+        }
+        else
+          return some(h);
+      }
+  }
+
+  /**
+   * Find smallest element greater or equal to the given one.
+   *
+   * @param a An element to compare with.
+   * @return Some smallest element in this set greater or equal to the given one, or None.
+   */
+  public final Option<A> lookupGE(final A a) {
+    Set<A> s = this;
+    Option<A> r = none();
+    while (true)
+      if (s.isEmpty())
+        return r;
+      else {
+        final A h = s.head();
+        final Ordering i = ord.compare(a, h);
+        if (i == LT) {
+          r = some(h);
+          s = s.l();
+        }
+        else if (i == GT)
+          s = s.r();
+        else
+          return some(h);
+      }
+  }
+
+  /**
    * Returns true if this set is a subset of the given set.
    *
    * @param s A set which is a superset of this set if this method returns true.

--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -129,8 +129,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    * @return A potential value for the given key.
    */
   public Option<V> get(final K k) {
-    final Option<P2<K, Option<V>>> x = tree.split(p(k, Option.none()))._2();
-    return x.bind(P2.__2());
+    return tree.lookup(p(k, Option.none())).bind(P2::_2);
   }
 
   /**

--- a/core/src/test/java/fj/data/SetTest.java
+++ b/core/src/test/java/fj/data/SetTest.java
@@ -2,6 +2,8 @@ package fj.data;
 
 import org.junit.Test;
 
+import static fj.data.Option.none;
+import static fj.data.Option.some;
 import static fj.Ord.intOrd;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -23,4 +25,18 @@ public class SetTest {
 		assertThat(s.toString(), equalTo("Set(1,2,3)"));
 	}
 
+	@Test
+	public void testLookups() {
+		Set<Integer> s = Set.set(intOrd, 5, 1, 7, 8);
+		assertThat(s.lookup(7), equalTo(some(7)));
+		assertThat(s.lookup(4), equalTo(none()));
+		assertThat(s.lookupLT(6), equalTo(some(5)));
+		assertThat(s.lookupLT(1), equalTo(none()));
+		assertThat(s.lookupGT(5), equalTo(some(7)));
+		assertThat(s.lookupGT(9), equalTo(none()));
+		assertThat(s.lookupLE(8), equalTo(some(8)));
+		assertThat(s.lookupLE(0), equalTo(none()));
+		assertThat(s.lookupGE(8), equalTo(some(8)));
+		assertThat(s.lookupGE(9), equalTo(none()));
+	}
 }


### PR DESCRIPTION
Hello!

TreeMap.get was using Set.split, so it was very slow on mid-sized trees because of the overhead of creating two subtrees every time, just to be discarded.

So I've added a new operation to Set, named 'peek' (i'm not native English speaker, so please feel free to use other name if you wish), wich, given some element, returns an element in the set wich equals to the one given, or None; it's just a fast loop search in the tree. Now, TreeMap can use 'peek' instead of 'split' for finding some value given a key, and it goes *a lot* faster now.

Greets!
