### PR TITLE
Force strict evaluation in 'TreeMap.map'.

### DIFF
--- a/core/src/main/java/fj/data/TreeMap.java
+++ b/core/src/main/java/fj/data/TreeMap.java
@@ -360,7 +360,7 @@ public final class TreeMap<K, V> implements Iterable<P2<K, V>> {
    */
   @SuppressWarnings("unchecked")
   public <W> TreeMap<K, W> map(final F<V, W> f) {
-    final F<P2<K, Option<V>>, P2<K, Option<W>>> g = P2.map2_(F1Functions.mapOption(f));
+    final F<P2<K, Option<V>>, P2<K, Option<W>>> g = compose(p2 -> p(p2._1(), p2._2()), P2.map2_(F1Functions.mapOption(f)));
     final F<K, P2<K, Option<V>>> coord = flip(P.<K, Option<V>>p2()).f(Option.none());
     final Ord<K> o = tree.ord().contramap(coord);
     return new TreeMap<>(tree.map(TreeMap.ord(o), g));


### PR DESCRIPTION
Hello again!

This program shows that `TreeMap.map` is lazy:
```java
import fj.Ord;
import fj.data.TreeMap;

public class Main {
  public static void main(final String[] args) {
    final TreeMap<Integer, Integer> treeMap =
        TreeMap.<Integer, Integer>empty(Ord.intOrd)
            .set(1, 10).set(2, 20).set(3, 30)
            .map(
                i -> {
                  System.out.println("Mapping...");
                  return i * 10;
                }
            );

    System.out.println("Done.");

    for (int i = 1; i <= 2; ++i) {
      System.out.println(String.format("*** Iteration %s ***", i));

      for (int k = 1; k <= 3; ++k) {
        System.out.println(String.format("Getting key %s...", k));

        for (int v : treeMap.get(k))
          System.out.println(v);
      }
    }
  }
}
```
... which gives the following output:
```
Done.
*** Iteration 1 ***
Getting key 1...
Mapping...
100
Getting key 2...
Mapping...
200
Getting key 3...
Mapping...
300
*** Iteration 2 ***
Getting key 1...
Mapping...
100
Getting key 2...
Mapping...
200
Getting key 3...
Mapping...
300
```
Well, I think this behaviour in is unintended! Laziness should be explicit, as stated in `Stream`'s documentation, otherwise assuming strict semantics. It's just a minimal example, but I came across this when, after building some immutable config objects from database recordsets (incredibly fast ;), the building code was really executed every time the treemap was accessed... and that hurts a lot.

With the modification in the pull request, the function `g`, built from the given `f` to be able map over the internal tree set structure, is composed with a little lambda that forces the evaluation of the lazy `P2` stub built by `P2.map2`. That's the modification with the minimal impact I've found, although it looks a little like a hack, so now it gives the following intended output:
```
Mapping...
Mapping...
Mapping...
Done.
*** Iteration 1 ***
Getting key 1...
100
Getting key 2...
200
Getting key 3...
300
*** Iteration 2 ***
Getting key 1...
100
Getting key 2...
200
Getting key 3...
300
```

Greets!