### PR TITLE
Change coverage executionData on root project to use wildcard path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,27 +129,26 @@ subprojects {
         reports {
             html.enabled = true
             xml.enabled = true
-            csv.enabled = false
-//        html.destination "${buildDir}/jacocoHtml"
         }
     }
 
-
-    task coverage(dependsOn: ["test", "jacocoTestReport"]) << {
-
-    }
+    task coverage(dependsOn: ["test", "jacocoTestReport"]) << {}
 
 }
 
 task coverage(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
-    dependsOn = subprojects.test
-    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories =  files(subprojects.sourceSets.main.output)
-    executionData = files(subprojects.jacocoTestReport.executionData)
+    dependsOn = subprojects.coverage
+    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+    subprojects.each {
+        // We only care about coverage of published artefacts:
+        if (it.uploadArchives.enabled) {
+            sourceSets it.sourceSets.main
+        }
+    }
+
     reports {
         html.enabled = true
         xml.enabled = true
-        csv.enabled = false
     }
 }
 
@@ -209,24 +208,4 @@ configure(subprojects.findAll { it.name != "props-core" }) {
 
 task env << {
 	println System.getenv()
-}
-
-task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
-	dependsOn = subprojects.jacocoTestReport
-	sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-	classDirectories = files(subprojects.sourceSets.main.output)
-	executionData = files(subprojects.jacocoTestReport.executionData)
-	reports {
-		xml.enabled true
-		xml.destination ="${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
-	}
-	// We could remove the following setOnlyIf line, but then
-	// jacocoRootReport would silently be SKIPPED if something with
-	// the projectsWithUnitTests is wrong (e.g. a project is missing
-	// in there).
-	setOnlyIf { true }
-}
-
-coveralls {
-	sourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs).files.absolutePath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,10 @@ buildscript {
     dependencies {
         classpath "com.ofg:uptodate-gradle-plugin:$uptodateVersion"
         classpath "me.tatarka:gradle-retrolambda:$retrolambdaPluginVersion"
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
     }
 }
 
 apply plugin: "jacoco"
-apply plugin: 'com.github.kt3k.coveralls'
 
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
@@ -139,12 +137,10 @@ subprojects {
 task coverage(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = subprojects.coverage
     executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
-    subprojects.each {
-        // We only care about coverage of published artefacts:
-        if (it.uploadArchives.enabled) {
-            sourceSets it.sourceSets.main
-        }
-    }
+    // We only care about coverage of:
+    def projectForFoverage = ["core", "java8", "quickcheck", "java-core"]
+    classDirectories = files(subprojects.findAll {subproject -> subproject.name in projectForFoverage} .sourceSets.main.output)
+    sourceDirectories = files(subprojects.findAll {subproject -> subproject.name in projectForFoverage} .sourceSets.main.allSource.srcDirs)
 
     reports {
         html.enabled = true


### PR DESCRIPTION
otherwise it is skipped because some sub-projects do not have execution Data.
Also only aggregate results for published artefacts.
Also removed unsused gradle task,