### PR TITLE
Fix broken NonEmptyList semigroup implementation.

### DIFF
--- a/core/src/main/java/fj/Semigroup.java
+++ b/core/src/main/java/fj/Semigroup.java
@@ -534,7 +534,7 @@ public final class Semigroup<A> {
     return semigroupDef(new Definition<NonEmptyList<A>>() {
       @Override
       public NonEmptyList<A> append(NonEmptyList<A> a1, NonEmptyList<A> a2) {
-        return a1.append(a1);
+        return a1.append(a2);
       }
 
       @Override

--- a/props-core-scalacheck/src/main/scala/fj/data/ArbitraryIO.scala
+++ b/props-core-scalacheck/src/main/scala/fj/data/ArbitraryIO.scala
@@ -1,0 +1,22 @@
+package fj.data
+
+import org.scalacheck.Arbitrary
+
+/**
+  *
+  */
+object ArbitraryIO {
+
+  implicit def arbitraryIO[T](implicit arbT: Arbitrary[T]): Arbitrary[IO[T]] =
+    Arbitrary(arbT.arbitrary.map(t => new IO[T]() {
+
+      override def run(): T = t
+
+      override def toString: String = t.toString
+
+      override def hashCode(): Int = t.hashCode()
+
+      override def equals(obj: scala.Any): Boolean = ???
+    }))
+
+}

--- a/props-core-scalacheck/src/main/scala/fj/data/ArbitraryIO.scala
+++ b/props-core-scalacheck/src/main/scala/fj/data/ArbitraryIO.scala
@@ -7,16 +7,12 @@ import org.scalacheck.Arbitrary
   */
 object ArbitraryIO {
 
+
+  private case class ArbIO[T](value: T) extends IO[T] {
+    override def run(): T = value
+  }
+
   implicit def arbitraryIO[T](implicit arbT: Arbitrary[T]): Arbitrary[IO[T]] =
-    Arbitrary(arbT.arbitrary.map(t => new IO[T]() {
-
-      override def run(): T = t
-
-      override def toString: String = t.toString
-
-      override def hashCode(): Int = t.hashCode()
-
-      override def equals(obj: scala.Any): Boolean = ???
-    }))
+    Arbitrary(arbT.arbitrary.map(ArbIO(_)))
 
 }

--- a/props-core-scalacheck/src/main/scala/fj/data/ArbitraryNatural.scala
+++ b/props-core-scalacheck/src/main/scala/fj/data/ArbitraryNatural.scala
@@ -1,0 +1,13 @@
+package fj.data
+
+import org.scalacheck.Arbitrary
+
+/**
+  * A Scalacheck [[Arbitrary]] for [[Natural]].
+  */
+object ArbitraryNatural {
+
+  implicit def arbitraryNatural: Arbitrary[Natural] =
+    Arbitrary(Arbitrary.arbBigInt.arbitrary.map(_.abs).map(bi => Natural.natural(bi.bigInteger).some()))
+
+}

--- a/props-core-scalacheck/src/main/scala/fj/data/ArbitraryNonEmptyList.scala
+++ b/props-core-scalacheck/src/main/scala/fj/data/ArbitraryNonEmptyList.scala
@@ -1,0 +1,16 @@
+package fj.data
+
+import fj.data.NonEmptyList.nel
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+
+/**
+  * A Scalacheck [[Arbitrary]] for [[NonEmptyList]].
+  */
+object ArbitraryNonEmptyList {
+  implicit def arbitraryNonEmptyList[A](implicit a: Arbitrary[A]): Arbitrary[NonEmptyList[A]] =
+    Arbitrary(nelOf(arbitrary[A]))
+
+  def nelOf[A](g: => Gen[A]): Gen[NonEmptyList[A]] =
+    Gen.nonEmptyListOf(g).map(l => l.tail.foldRight(nel(l.head))((x, n) => n.cons(x)))
+}

--- a/props-core-scalacheck/src/test/scala/fj/CheckSemigroup.scala
+++ b/props-core-scalacheck/src/test/scala/fj/CheckSemigroup.scala
@@ -1,0 +1,152 @@
+package fj
+
+import fj.ArbitraryP._
+import fj.ArbitraryUnit.arbitraryUnit
+import fj.Ord.intOrd
+import fj.data.ArbitraryArray.arbitraryArray
+import fj.data.ArbitraryIO.arbitraryIO
+import fj.data.ArbitraryList.arbitraryList
+import fj.data.ArbitraryNatural.arbitraryNatural
+import fj.data.ArbitraryNonEmptyList.arbitraryNonEmptyList
+import fj.data.ArbitraryOption.arbitraryOption
+import fj.data.ArbitrarySet.arbitrarySet
+import fj.data.ArbitraryStream.arbitraryStream
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Properties}
+
+/**
+  * Scalacheck [[Properties]] for [[Semigroup]] implementations.
+  *
+  * @param s         a Semigroup implementation.
+  * @param desc      a description of the Semigroup implementation.
+  * @param arbitrary a Scalacheck [[Arbitrary]] implementation for the Semigroup's type.
+  * @tparam T the type to which the Semigroup applies.
+  */
+case class SemigroupProperties[T](s: Semigroup[T], desc: String)(implicit val arbitrary: Arbitrary[T]) extends Properties(desc) {
+
+
+  property("sum(x,y)") = forAll((x: T, y: T, z: T) =>
+    s.sum(s.sum(x, y), z) == s.sum(x, s.sum(y, z)))
+
+  property("sum()") = forAll((x: T, y: T, z: T) => {
+    val sf = s.sum()
+    sf.f(sf.f(x).f(y)).f(z) == sf.f(x).f(sf.f(y).f(z))
+  })
+
+  property("dual()") = forAll((x: T, y: T, z: T) => {
+    val sd = s.dual()
+    sd.sum(sd.sum(x, y), z) == sd.sum(x, sd.sum(y, z))
+  })
+
+  property("sum(x)") = forAll((x: T, y: T) =>
+    s.sum(x).f(y) == s.sum(x, y))
+
+}
+
+
+/**
+  *
+  */
+object CheckSemigroup extends Properties("Semigroup") {
+
+
+  def idInt(n: Int): java.lang.Integer = n
+
+  implicit def oi: Ord[Int] = intOrd.contramap(idInt _)
+
+  implicit lazy val arbJavaBigDecimal: Arbitrary[java.math.BigDecimal] = Arbitrary(
+    Arbitrary.arbLong.arbitrary.map(l => new java.math.BigDecimal(l))
+  )
+
+  implicit lazy val arbJavaBigInteger: Arbitrary[java.math.BigInteger] = Arbitrary(
+    Arbitrary.arbBigInt.arbitrary.map(_.bigInteger)
+  )
+
+  implicit lazy val arbJavaInteger: Arbitrary[Integer] = Arbitrary(
+    Arbitrary.arbInt.arbitrary.map(i => i)
+  )
+
+  implicit lazy val arbJavaLong: Arbitrary[java.lang.Long] = Arbitrary(
+    Arbitrary.arbLong.arbitrary.map(i => i)
+  )
+
+  implicit lazy val arbJavaBoolean: Arbitrary[java.lang.Boolean] = Arbitrary(
+    Arbitrary.arbBool.arbitrary.map(b => b)
+  )
+
+  implicit lazy val arbStringBuilder: Arbitrary[java.lang.StringBuilder] = Arbitrary(
+    Arbitrary.arbString.arbitrary.map(new java.lang.StringBuilder(_))
+  )
+
+  implicit lazy val arbStringBuffer: Arbitrary[StringBuffer] = Arbitrary(
+    Arbitrary.arbString.arbitrary.map(new StringBuffer(_))
+  )
+
+  include(SemigroupProperties(Semigroup.arraySemigroup[Int](), "arraySemigroup()"))
+
+  include(SemigroupProperties(Semigroup.bigdecimalAdditionSemigroup, "bigdecimalAdditionSemigroup"))
+  include(SemigroupProperties(Semigroup.bigdecimalMultiplicationSemigroup, "bigdecimalMultiplicationSemigroup"))
+  include(SemigroupProperties(Semigroup.bigDecimalMaximumSemigroup, "bigDecimalMaximumSemigroup"))
+  include(SemigroupProperties(Semigroup.bigDecimalMinimumSemigroup, "bigDecimalMinimumSemigroup"))
+
+  include(SemigroupProperties(Semigroup.bigintAdditionSemigroup, "bigintAdditionSemigroup"))
+  include(SemigroupProperties(Semigroup.bigintMultiplicationSemigroup, "bigintMultiplicationSemigroup"))
+  include(SemigroupProperties(Semigroup.bigintMaximumSemigroup, "bigintMaximumSemigroup"))
+  include(SemigroupProperties(Semigroup.bigintMinimumSemigroup, "bigintMinimumSemigroup"))
+
+  include(SemigroupProperties(Semigroup.conjunctionSemigroup, "conjunctionSemigroup"))
+  include(SemigroupProperties(Semigroup.disjunctionSemigroup, "disjunctionSemigroup"))
+  include(SemigroupProperties(Semigroup.exclusiveDisjunctionSemiGroup, "exclusiveDisjunctionSemiGroup"))
+
+  include(SemigroupProperties(Semigroup.firstOptionSemigroup[Int](), "firstOptionSemigroup()"))
+  include(SemigroupProperties(Semigroup.firstSemigroup[Int](), "firstSemigroup()"))
+
+  include(SemigroupProperties(Semigroup.intAdditionSemigroup, "intAdditionSemigroup"))
+  include(SemigroupProperties(Semigroup.intMultiplicationSemigroup, "intMultiplicationSemigroup"))
+  include(SemigroupProperties(Semigroup.intMaximumSemigroup, "intMaximumSemigroup"))
+  include(SemigroupProperties(Semigroup.intMinimumSemigroup, "intMinimumSemigroup"))
+
+  include(SemigroupProperties(Semigroup.ioSemigroup[String](Semigroup.stringSemigroup), "ioSemigroup(Semigroup)"))
+
+  include(SemigroupProperties(Semigroup.lastOptionSemigroup[Int](), "lastOptionSemigroup()"))
+  include(SemigroupProperties(Semigroup.lastSemigroup[Int](), "lastSemigroup()"))
+
+  include(SemigroupProperties(Semigroup.longAdditionSemigroup, "longAdditionSemigroup"))
+  include(SemigroupProperties(Semigroup.longMultiplicationSemigroup, "longMultiplicationSemigroup"))
+  include(SemigroupProperties(Semigroup.longMaximumSemigroup, "longMaximumSemigroup"))
+  include(SemigroupProperties(Semigroup.longMinimumSemigroup, "longMinimumSemigroup"))
+
+
+  include(SemigroupProperties(Semigroup.listSemigroup[Int], "listSemigroup"))
+
+  include(SemigroupProperties(Semigroup.naturalAdditionSemigroup, "naturalAdditionSemigroup"))
+  include(SemigroupProperties(Semigroup.naturalMaximumSemigroup, "naturalMaximumSemigroup"))
+  include(SemigroupProperties(Semigroup.naturalMinimumSemigroup, "naturalMinimumSemigroup"))
+  include(SemigroupProperties(Semigroup.naturalMultiplicationSemigroup, "naturalMultiplicationSemigroup"))
+
+  include(SemigroupProperties(Semigroup.nonEmptyListSemigroup[Int], "nonEmptyListSemigroup"))
+
+  include(SemigroupProperties(Semigroup.p1Semigroup(Semigroup.intAdditionSemigroup), "p1Semigroup(Semigroup<A>)"))
+  include(SemigroupProperties(Semigroup.p2Semigroup(Semigroup.intAdditionSemigroup, Semigroup.stringSemigroup), "p2Semigroup(Semigroup<A>,Semigroup<B>)"))
+
+  include(SemigroupProperties(Semigroup.semigroup[Int](new F2[Int, Int, Int] {
+    def f(x: Int, y: Int): Int = x + y
+  }), "semigroup(F<A,A,A>)"))
+
+  include(SemigroupProperties(Semigroup.semigroup[Int](new F[Int, F[Int, Int]] {
+    def f(x: Int): F[Int, Int] = (y: Int) => x + y
+  }), "semigroup(F<A,F<A,A>>)"))
+
+  include(SemigroupProperties(Semigroup.setSemigroup[Int](), "setSemigroup()"))
+  include(SemigroupProperties(Semigroup.streamSemigroup[Int](), "streamSemigroup"))
+
+  include(SemigroupProperties(Semigroup.stringSemigroup, "stringSemigroup"))
+  include(SemigroupProperties(Semigroup.stringBufferSemigroup, "stringBufferSemigroup"))
+  include(SemigroupProperties(Semigroup.stringBuilderSemigroup, "stringBuilderSemigroup"))
+
+
+  include(SemigroupProperties(Semigroup.unitSemigroup, "unitSemigroup"))
+
+
+}

--- a/props-core-scalacheck/src/test/scala/fj/Tests.scala
+++ b/props-core-scalacheck/src/test/scala/fj/Tests.scala
@@ -1,8 +1,9 @@
 package fj
 
 object Tests {
-  def tests = List (
+  def tests = List(
     CheckP2.properties,
+    CheckSemigroup.properties,
     fj.data.CheckArray.properties,
     fj.data.CheckIO.properties,
     fj.data.CheckIteratee.properties,
@@ -19,26 +20,27 @@ object Tests {
 
   def main(args: Array[String]) {
     run(tests)
-//    System.exit(0)
+    //    System.exit(0)
   }
 
-  import org.scalacheck.Prop
-  import org.scalacheck.Test
   import org.scalacheck.Test.check
+  import org.scalacheck.{Prop, Test}
 
   def run(tests: List[(String, Prop)]) =
     tests foreach { case (name, p) => {
-        val c = check(new Test.Parameters.Default { override val maxSize = 20 }, p)
-        c.status match {
-          case Test.Passed => println("Passed " + name)
-          case Test.Proved(_) => println("Proved " + name)
-          case f @ Test.Failed(_, _) => sys.error(name + ": " + f)
-          case Test.Exhausted => println("Exhausted " + name)
-          case f @ Test.PropException(_, e, _) => {
-            e.printStackTrace
-            sys.error(name + ": " + f)
-          }
+      val c = check(new Test.Parameters.Default {
+        override val maxSize = 20
+      }, p)
+      c.status match {
+        case Test.Passed => println("Passed " + name)
+        case Test.Proved(_) => println("Proved " + name)
+        case f@Test.Failed(_, _) => sys.error(name + ": " + f)
+        case Test.Exhausted => println("Exhausted " + name)
+        case f@Test.PropException(_, e, _) => {
+          e.printStackTrace
+          sys.error(name + ": " + f)
         }
       }
+    }
     }
 }


### PR DESCRIPTION
I found a bug in the NonEmptyList semigroup implementation when I attempt to update one of my projects to use 4.7.  I've fixed the bug and added some Scalacheck test coverage for the Semigroup class and its implementations.  I also created some new implicit conversions of the Scalacheck Arbitrary to facilitate the new tests.