### PR TITLE
Reference from static field of LazyString class to Equal class removed

### DIFF
--- a/core/src/main/java/fj/Equal.java
+++ b/core/src/main/java/fj/Equal.java
@@ -674,7 +674,7 @@ public final class Equal<A> {
   /**
    * An equal instance for lazy strings.
    */
-  public static final Equal<LazyString> eq = streamEqual(charEqual).contramap(LazyString.toStream);
+  public static final Equal<LazyString> eq = streamEqual(charEqual).contramap(LazyString::toStream);
 
   /**
    * An equal instance for the empty heterogeneous list.

--- a/core/src/main/java/fj/Equal.java
+++ b/core/src/main/java/fj/Equal.java
@@ -292,11 +292,6 @@ public final class Equal<A> {
   public static final Equal<BitSet> bitSetSequal = equalDef((bs1, bs2) -> bs1.longValue() == bs2.longValue());
 
   /**
-   * An equal instance for the {@link Stream} of {@link Character}.
-   */
-  public static final Equal<Stream<Character>> streamCharacterEqual = streamEqual(charEqual);
-
-  /**
    * An equal instance for the {@link Either} type.
    *
    * @param ea Equality across the left side of {@link Either}.

--- a/core/src/main/java/fj/Equal.java
+++ b/core/src/main/java/fj/Equal.java
@@ -292,6 +292,11 @@ public final class Equal<A> {
   public static final Equal<BitSet> bitSetSequal = equalDef((bs1, bs2) -> bs1.longValue() == bs2.longValue());
 
   /**
+   * An equal instance for the {@link Stream} of {@link Character}.
+   */
+  public static final Equal<Stream<Character>> streamCharacterEqual = streamEqual(charEqual);
+
+  /**
    * An equal instance for the {@link Either} type.
    *
    * @param ea Equality across the left side of {@link Either}.

--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -11,7 +11,7 @@ import static fj.data.Stream.join;
 import static fj.function.Booleans.or;
 import static fj.function.Characters.isSpaceChar;
 import static fj.Equal.charEqual;
-import static fj.Equal.streamCharacterEqual;
+import static fj.Equal.streamEqual;
 
 import java.util.regex.Pattern;
 
@@ -234,7 +234,7 @@ public final class LazyString implements CharSequence {
    * @return The first index of the given substring in this lazy string, or None if there is no such substring.
    */
   public Option<Integer> indexOf(final LazyString cs) {
-    return s.substreams().indexOf(streamCharacterEqual.eq(cs.s));
+    return s.substreams().indexOf(Consts.eqS.eq(cs.s));
   }
 
   /**
@@ -342,4 +342,15 @@ public final class LazyString implements CharSequence {
   public static final F<Stream<Character>, LazyString> fromStream =
           LazyString::fromStream;
 
+  /**
+   * Static constants that should be placed in different class to prevent cycle references
+   * in static initializer
+   */
+  private static class Consts {
+    private Consts() {
+      throw new UnsupportedOperationException();
+    }
+
+    public static final Equal<Stream<Character>> eqS = streamEqual(charEqual);
+  }
 }

--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -234,7 +234,7 @@ public final class LazyString implements CharSequence {
    * @return The first index of the given substring in this lazy string, or None if there is no such substring.
    */
   public Option<Integer> indexOf(final LazyString cs) {
-    return s.substreams().indexOf(Consts.eqS.eq(cs.s));
+    return s.substreams().indexOf(eqS.eq(cs.s));
   }
 
   /**
@@ -342,15 +342,6 @@ public final class LazyString implements CharSequence {
   public static final F<Stream<Character>, LazyString> fromStream =
           LazyString::fromStream;
 
-  /**
-   * Static constants that should be placed in different class to prevent cycle references
-   * in static initializer
-   */
-  private static class Consts {
-    private Consts() {
-      throw new UnsupportedOperationException();
-    }
+  private static final Equal<Stream<Character>> eqS = streamEqual(charEqual);
 
-    public static final Equal<Stream<Character>> eqS = streamEqual(charEqual);
-  }
 }

--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -11,7 +11,7 @@ import static fj.data.Stream.join;
 import static fj.function.Booleans.or;
 import static fj.function.Characters.isSpaceChar;
 import static fj.Equal.charEqual;
-import static fj.Equal.streamEqual;
+import static fj.Equal.streamCharacterEqual;
 
 import java.util.regex.Pattern;
 
@@ -234,7 +234,7 @@ public final class LazyString implements CharSequence {
    * @return The first index of the given substring in this lazy string, or None if there is no such substring.
    */
   public Option<Integer> indexOf(final LazyString cs) {
-    return s.substreams().indexOf(eqS.eq(cs.s));
+    return s.substreams().indexOf(streamCharacterEqual.eq(cs.s));
   }
 
   /**
@@ -341,7 +341,5 @@ public final class LazyString implements CharSequence {
    */
   public static final F<Stream<Character>, LazyString> fromStream =
           LazyString::fromStream;
-
-  private static final Equal<Stream<Character>> eqS = streamEqual(charEqual);
 
 }


### PR DESCRIPTION
Cause it could cause deadlock on parallel static initialization.