### PR TITLE
Fix a recursive trampoline call in the Eval Defer implementation

### DIFF
--- a/core/src/main/java/fj/data/Eval.java
+++ b/core/src/main/java/fj/data/Eval.java
@@ -232,7 +232,7 @@ public abstract class Eval<A> {
 
     @Override
     protected final Trampoline<A> trampoline() {
-      return memo._1().asTrampoline().trampoline();
+      return Trampoline.suspend(P.lazy(() -> memo._1().asTrampoline().trampoline()));
     }
   }
 }


### PR DESCRIPTION
Ran into a recursive `trampoline()` method invocation, this time in `Defer`. Improved the unit test.