### PR TITLE
Stream to allow multiple evaluation strategy (WIP)

### DIFF
--- a/core/src/main/java/fj/F2Functions.java
+++ b/core/src/main/java/fj/F2Functions.java
@@ -144,7 +144,7 @@ public final class F2Functions {
         return new F2<Tree<A>, Tree<B>, Tree<C>>() {
             public Tree<C> f(final Tree<A> as, final Tree<B> bs) {
                 final F2<Tree<A>, Tree<B>, Tree<C>> self = this;
-                return node(f.f(as.root(), bs.root()), P.lazy(() -> streamM(self).f(as.subForest()._1(), bs.subForest()._1())));
+                return node(f.f(as.root(), bs.root()), Stream.byName(() -> streamM(self).f(as.subforest(), bs.subforest())));
             }
         };
     }
@@ -215,7 +215,7 @@ public final class F2Functions {
         return new F2<Tree<A>, Tree<B>, Tree<C>>() {
             public Tree<C> f(final Tree<A> ta, final Tree<B> tb) {
                 final F2<Tree<A>, Tree<B>, Tree<C>> self = this;
-                return node(f.f(ta.root(), tb.root()), P.lazy(() -> zipStreamM(self).f(ta.subForest()._1(), tb.subForest()._1())));
+                return node(f.f(ta.root(), tb.root()), Stream.byName(() -> zipStreamM(self).f(ta.subforest(), tb.subforest())));
             }
         };
     }

--- a/core/src/main/java/fj/Function.java
+++ b/core/src/main/java/fj/Function.java
@@ -741,7 +741,19 @@ public final class Function {
    * @return A new function after performing the composition, then application.
    */
   public static <A, B, C, D> F<D, C> bind(final F<D, A> ca, final F<D, B> cb, final F<A, F<B, C>> f) {
-    return apply(compose(f, ca), cb);
+    return d -> f.f(ca.f(d)).f(cb.f(d));
+  }
+
+  /**
+   * Binds the given function <em>f</em> to the values of the given functions, with a final join.
+   *
+   * @param ca A function to bind <em>f</em> function to.
+   * @param cb A function to bind <em>f</em> function to.
+   * @param f  The bound function to be composed with <em>ca</em> and then applied with <em>cb</em>
+   * @return A new function after performing the composition, then application.
+   */
+  public static <A, B, C, D> F<D, C> bind(final F<D, A> ca, final F<D, B> cb, final F2<A, B, C> f) {
+    return d -> f.f(ca.f(d), cb.f(d));
   }
 
   /**

--- a/core/src/main/java/fj/Hash.java
+++ b/core/src/main/java/fj/Hash.java
@@ -3,6 +3,7 @@ package fj;
 import static fj.Function.compose;
 
 import fj.data.*;
+import fj.data.Stream.EvaluatedStream;
 import fj.data.vector.V2;
 import fj.data.vector.V3;
 import fj.data.vector.V4;
@@ -232,11 +233,12 @@ public final class Hash<A> {
     return hash(as -> {
         final int p = 419;
         int r = 239;
-        Stream<A> aas = as;
+
+        EvaluatedStream<A> aas = as.eval();
 
         while (!aas.isEmpty()) {
-            r = p * r + ha.hash(aas.head());
-            aas = aas.tail()._1();
+            r = p * r + ha.hash(aas.unsafeHead());
+            aas = aas.unsafeTail().eval();
         }
 
         return r;

--- a/core/src/main/java/fj/P1.java
+++ b/core/src/main/java/fj/P1.java
@@ -160,7 +160,7 @@ public abstract class P1<A> implements F0<A> {
      * @return A single P1 for the given stream.
      */
     public static <A> P1<Stream<A>> sequence(final Stream<P1<A>> as) {
-        return as.foldRight(liftM2(Stream.cons()), p(Stream.nil()));
+        return P.p(as.map(P1.__1()));
     }
 
 	/**

--- a/core/src/main/java/fj/P2.java
+++ b/core/src/main/java/fj/P2.java
@@ -155,9 +155,7 @@ public abstract class P2<A, B> {
    * @return A stream of the results of applying the given stream of functions to this product.
    */
   public final <C> Stream<C> sequenceW(final Stream<F<P2<A, B>, C>> fs) {
-    return fs.isEmpty()
-           ? Stream.nil()
-           : Stream.cons(fs.head().f(this), () -> sequenceW(fs.tail()._1()));
+    return fs.uncons(Stream.nil(), (h, tail) -> Stream.cons(h.f(this), () -> sequenceW(tail)));
   }
 
   /**

--- a/core/src/main/java/fj/Semigroup.java
+++ b/core/src/main/java/fj/Semigroup.java
@@ -38,12 +38,16 @@ public final class Semigroup<A> {
 
     A append(A a1, A a2);
 
+    default A append(A a1, F0<A> a2) {
+      return append(a1, a2.f());
+    }
+
     default F<A, A> prepend(A a) {
       return a2 -> append(a, a2);
     }
 
-    default A sum(A a, F0<Stream<A>> as) {
-      return as.f().foldLeft(this::append, a);
+    default A sum(A a, Stream<A> as) {
+      return as.foldLeft(this::append, a);
     }
 
     default A multiply1p(int n, A a) {
@@ -158,7 +162,7 @@ public final class Semigroup<A> {
    * Sums the given values with left-fold, shortcutting the computation as early as possible.
    */
   public A sumStream(A a, F0<Stream<A>> as) {
-    return def.sum(a, as);
+    return def.sum(a, Stream.byName(as));
   }
 
   /**
@@ -190,9 +194,9 @@ public final class Semigroup<A> {
       }
 
       @Override
-      public Option<A> sum(F0<Stream<Option<A>>> oas) {
-        Stream<A> as = oas.f().bind(Option::toStream);
-        return as.uncons(none(), h -> tail ->  some(def.sum(h, tail::_1)));
+      public Option<A> sum(Stream<Option<A>> oas) {
+        Stream<A> as = oas.bind(Option::toStream);
+        return as.uncons(none(), (h, tail) ->  some(def.sum(h, tail)));
       }
     });
   }
@@ -224,8 +228,8 @@ public final class Semigroup<A> {
       }
 
       @Override
-      public B sum(B b, F0<Stream<B>> bs) {
-        return f.f(def.sum(g.f(b), () -> bs.f().map(g)));
+      public B sum(B b, Stream<B> bs) {
+        return f.f(def.sum(g.f(b), bs.map(g)));
       }
     });
   }
@@ -253,8 +257,8 @@ public final class Semigroup<A> {
       }
 
       @Override
-      public C sum(C c1, F0<Stream<C>> cs) {
-        return c.f(saDef.sum(a.f(c1), () -> cs.f().map(a)), sbDef.sum(b.f(c1), () -> cs.f().map(b)));
+      public C sum(C c1, Stream<C> cs) {
+        return c.f(saDef.sum(a.f(c1), cs.map(a)), sbDef.sum(b.f(c1), cs.map(b)));
       }
     });
   }
@@ -476,7 +480,7 @@ public final class Semigroup<A> {
         }
 
         @Override
-        public A sum(A a, F0<Stream<A>> as) {
+        public A sum(A a, Stream<A> as) {
           return a;
         }
       });
@@ -538,8 +542,8 @@ public final class Semigroup<A> {
       }
 
       @Override
-      public NonEmptyList<A> sum(NonEmptyList<A> nea, F0<Stream<NonEmptyList<A>>> neas) {
-        List<A> tail = neas.f().map(nel -> listDList(nel.toList())).foldLeft(DList::append, DList.<A>nil()).run();
+      public NonEmptyList<A> sum(NonEmptyList<A> nea, Stream<NonEmptyList<A>> neas) {
+        List<A> tail = neas.map(nel -> listDList(nel.toList())).foldLeft(DList::append, DList.<A>nil()).run();
         return nea.append(tail);
       }
     });
@@ -611,8 +615,8 @@ public final class Semigroup<A> {
       }
 
       @Override
-      public P1<A> sum(P1<A> ap1, F0<Stream<P1<A>>> as) {
-        return P.lazy(() -> def.sum(ap1._1(), () -> as.f().map(P1.__1())));
+      public P1<A> sum(P1<A> ap1, Stream<P1<A>> as) {
+        return P.lazy(() -> def.sum(ap1._1(), as.map(P1.__1())));
       }
     });
   }

--- a/core/src/main/java/fj/data/Java.java
+++ b/core/src/main/java/fj/data/Java.java
@@ -404,27 +404,7 @@ public final class Java {
    * @return A function that converts streams to iterable.
    */
   public static <A> F<Stream<A>, Iterable<A>> Stream_Iterable() {
-    return as -> () -> new Iterator<A>() {
-      private Stream<A> x = as;
-
-      public boolean hasNext() {
-        return x.isNotEmpty();
-      }
-
-      public A next() {
-        if (x.isEmpty())
-          throw new NoSuchElementException("Empty iterator");
-        else {
-          final A a = x.head();
-          x = x.tail()._1();
-          return a;
-        }
-      }
-
-      public void remove() {
-        throw new UnsupportedOperationException();
-      }
-    };
+    return as -> as;
   }
 
   /**

--- a/core/src/main/java/fj/data/LazyString.java
+++ b/core/src/main/java/fj/data/LazyString.java
@@ -35,9 +35,8 @@ public final class LazyString implements CharSequence {
     return new LazyString(Stream.unfold(o -> {
         final String s2 = o._1();
         final int n = o._2();
-        final Option<P2<Character, P2<String, Integer>>> none = none();
-        return s2.length() <= n ? none : some(p(s2.charAt(n), p(s2, n + 1)));
-      }, p(s, 0)));
+        return s2.length() <= n ? none() : some(p(s2.charAt(n), p(s2, n + 1)));
+      }, p(s, 0)).weakMemo());
   }
 
   /**
@@ -52,7 +51,7 @@ public final class LazyString implements CharSequence {
    * @return A lazy string with the characters from the given stream.
    */
   public static LazyString fromStream(final Stream<Character> s) {
-    return new LazyString(s);
+    return new LazyString(s.weakMemo());
   }
 
   /**
@@ -109,7 +108,7 @@ public final class LazyString implements CharSequence {
   }
 
   public String toStringLazy() {
-    return s.isEmpty() ? "" : "LazyString(" + Show.charShow.showS(s.head()) + ", ?)";
+    return s.uncons("", (head, tail) -> "LazyString(" + Show.charShow.showS(head) + ", ?)");
   }
 
   @Override

--- a/core/src/main/java/fj/data/PriorityQueue.java
+++ b/core/src/main/java/fj/data/PriorityQueue.java
@@ -102,7 +102,7 @@ public final class PriorityQueue<K, A> {
     public List<P2<K, A>> topN() {
         return toStream().uncons(
             List.nil(),
-            top -> tail -> List.cons(top, tail._1().takeWhile(compose(equal.eq(top._1()), P2.__1())).toList())
+            (top, tail) -> List.cons(top, tail.takeWhile(compose(equal.eq(top._1()), P2.__1())).toList())
         );
     }
 

--- a/core/src/main/java/fj/data/hamt/BitSet.java
+++ b/core/src/main/java/fj/data/hamt/BitSet.java
@@ -149,7 +149,7 @@ public final class BitSet {
     }
 
     public <A> A foldRight(final F2<Boolean, A, A> f, A acc) {
-        return toStream().foldRight(b -> p -> f.f(b, p._1()), acc);
+        return toStream().foldRight1(b -> a -> f.f(b, a), acc);
     }
 
     public <A> A foldLeft(final F2<A, Boolean, A> f, A acc) {

--- a/core/src/test/java/fj/data/StreamTest.java
+++ b/core/src/test/java/fj/data/StreamTest.java
@@ -42,10 +42,10 @@ public class StreamTest {
     public void iterableStreamWithStructureUpdate() {
         java.util.List<Integer> list = List.list(1, 2, 3).toJavaList();
         Stream<Integer> s1 = Stream.iterableStream(list);
-        int x = s1.head();
+        int x = s1.eval().unsafeHead();
         list.remove(1);
-        Stream<Integer> s2 = s1.tail()._1();
-        x = s2.head();
+        Stream<Integer> s2 = s1.eval().unsafeTail();
+        x = s2.eval().unsafeHead();
     }
 
 

--- a/demo/src/main/java/fj/demo/Comonad_example.java
+++ b/demo/src/main/java/fj/demo/Comonad_example.java
@@ -25,9 +25,7 @@ public class Comonad_example {
     Stream<Stream<Character>> r = single(Stream.nil());
     for (final Zipper<Character> z : fromStream(s))
       r = join(z.cobind(zp ->
-            perms(zp.lefts().reverse().append(zp.rights())).map(
-                F1Functions.o(Stream.<Character>cons().f(zp.focus()), P.p1())
-            )
+            perms(zp.lefts().reverse().append(zp.rights())).map(cs -> Stream.cons(zp.focus(), cs))
       ).toStream());
     return r;
   }

--- a/demo/src/main/java/fj/demo/euler/Problem3.java
+++ b/demo/src/main/java/fj/demo/euler/Problem3.java
@@ -1,6 +1,5 @@
 package fj.demo.euler;
 
-import fj.P1;
 import static fj.data.Enumerator.naturalEnumerator;
 import fj.data.Natural;
 import static fj.data.Natural.ZERO;
@@ -16,29 +15,33 @@ import static fj.Show.naturalShow;
  */
 public class Problem3 {
   // An infinite stream of all the primes.
-  public static final Stream<Natural> primes = cons(natural(2).some(), () -> forever(naturalEnumerator, natural(3).some(), 2).filter(n -> primeFactors(n).length() == 1));
+  public static final Stream<Natural> primes = cons(
+      natural(2).some(),
+      forever(naturalEnumerator, natural(3).some(), 2)
+          .filter(n -> primeFactors(n).eval().unsafeTail().isEmpty())
+  );
 
   //Finds factors of a given number.
-  public static Stream<Natural> factor(final Natural n, final Natural p, final P1<Stream<Natural>> ps) {
-    Stream<Natural> ns = cons(p, ps);
-    Stream<Natural> ret = nil();
-    while (ns.isNotEmpty() && ret.isEmpty()) {
-      final Natural h = ns.head();
-      final P1<Stream<Natural>> t = ns.tail();
+  public static Stream<Natural> factor(final Natural n, final Natural p, final Stream<Natural> ps) {
+    EvaluatedStream<Natural> ns = cons(p, ps).eval();
+    EvaluatedStream<Natural> ret = Stream.<Natural>nil().eval();
+    while (!ns.isEmpty() && ret.isEmpty()) {
+      final Natural h = ns.unsafeHead();
+      final Stream<Natural> t = ns.unsafeTail();
       if (naturalOrd.isGreaterThan(h.multiply(h), n))
-        ret = single(n);
+        ret = single(n).eval();
       else {
         final V2<Natural> dm = n.divmod(h);
         if (naturalOrd.eq(dm._2(), ZERO))
-          ret = cons(h, () -> factor(dm._1(), h, t));
-        else ns = ns.tail()._1();
+          ret = cons(h, () -> factor(dm._1(), h, t)).eval();
+        else ns = ns.unsafeTail().eval();
       }
     }
     return ret;
   }
 
   // Finds the prime factors of a given number.
-  public static Stream<Natural> primeFactors(final Natural n) {return factor(n, natural(2).some(), primes.tail());}
+  public static Stream<Natural> primeFactors(final Natural n) {return factor(n, natural(2).some(), primes.eval().unsafeTail());}
 
   public static void main(final String[] args) {
     naturalShow.println(primeFactors(natural(600851475143L).some()).last());

--- a/props-core-scalacheck/src/test/scala/fj/data/CheckStream.scala
+++ b/props-core-scalacheck/src/test/scala/fj/data/CheckStream.scala
@@ -22,11 +22,11 @@ object CheckStream extends Properties("Stream") {
 
   property("orHead") = forAll((a: Stream[Int], n: P1[Int]) =>
     a.isNotEmpty ==>
-    (a.orHead(n) == a.head))
+    (a.orHead(n) == a.eval().unsafeHead()))
 
   property("orTail") = forAll((a: Stream[String], n: P1[Stream[String]]) =>
     a.isNotEmpty ==>
-    (streamEqual(stringEqual).eq(a.orTail(n)._1, a.tail._1)))
+    (streamEqual(stringEqual).eq(a.orTail(n)._1, a.eval().unsafeTail())))
 
   property("toOption") = forAll((a: Stream[Int]) =>
     a.toOption.isNone || a.toOption.some == a.head)
@@ -114,12 +114,12 @@ object CheckStream extends Properties("Stream") {
       a.cons(b)))
 
   property("foldRight") = forAll((a: Stream[String]) => streamEqual(stringEqual).eq(
-      a.foldRight((a: String, b: P1[Stream[String]]) => b._1.cons(a), nil[String]), a))
+      a.foldRight((a: String, b: F0[Stream[String]]) => b.f().cons(a), nil[String]), a))
                                      
   property("foldLeft") = forAll((a: Stream[String], s: String) =>
     streamEqual(stringEqual).eq(
       a.foldLeft(((a: Stream[String], b: String) => single(b).append(a)), nil[String]),
-      a.reverse.foldRight((a: String, b: P1[Stream[String]]) => single(a).append(b._1), nil[String])))
+      a.reverse.foldRight((a: String, b: F0[Stream[String]]) => single(a).append(b), nil[String])))
 
   property("length") = forAll((a: Stream[String]) =>
     a.length != 0 ==>
@@ -151,7 +151,7 @@ object CheckStream extends Properties("Stream") {
 
   property("join") = forAll((a: Stream[Stream[String]]) =>
     streamEqual(stringEqual).eq(
-      a.foldRight((a: Stream[String], b: P1[Stream[String]]) => a.append(b._1), nil[String]),
+      a.foldRight((a: Stream[String], b: F0[Stream[String]]) => a.append(b), nil[String]),
       join(a)))
                   /*
   property("sort") = forAll((a: Stream[String]) => {

--- a/props-core/src/test/java/fj/data/properties/StreamProperties.java
+++ b/props-core/src/test/java/fj/data/properties/StreamProperties.java
@@ -192,7 +192,7 @@ public class StreamProperties {
   @CheckParams(maxSize = 500)
   public Property join() {
     return property(arbStream(arbStream(arbInteger)), (Stream<Stream<Integer>> stream) ->
-      prop(eq.eq(stream.foldRight((Stream<Integer> i, P1<Stream<Integer>> s) -> i.append(s._1()), nil()),
+      prop(eq.eq(stream.foldRight((Stream<Integer> i, F0<Stream<Integer>> s) -> i.append(s), nil()),
         Stream.join(stream))));
   }
 
@@ -200,5 +200,11 @@ public class StreamProperties {
   public Property sort() {
     return property(arbStream(arbInteger), (Stream<Integer> stream) ->
       prop(eq.eq(stream.sort(intOrd), stream.toList().sort(intOrd).toStream())));
+  }
+
+  @CheckParams(maxSize = 1000)
+  public Property cycle() {
+    return property(arbStream(arbInteger), (Stream<Integer> stream) ->
+        prop(eq.eq(Stream.cycle(Stream.cons(0, stream.take(3))).take(2 + stream.take(3).length() * 2), Stream.cons(0, stream.take(3)).append(Stream.cons(0, stream.take(3))))));
   }
 }

--- a/quickcheck/src/main/java/fj/test/Cogen.java
+++ b/quickcheck/src/main/java/fj/test/Cogen.java
@@ -6,6 +6,7 @@ import static fj.Function.curry;
 import static fj.P.p;
 
 import fj.data.*;
+import fj.data.Stream.EvaluatedStream;
 
 import static fj.data.Array.array;
 import static fj.data.Array.iterableArray;
@@ -444,9 +445,10 @@ public abstract class Cogen<A> {
   public static <A> Cogen<Stream<A>> cogenStream(final Cogen<A> ca) {
     return new Cogen<Stream<A>>() {
       public <B> Gen<B> cogen(final Stream<A> as, final Gen<B> g) {
-        return as.isEmpty() ?
+        EvaluatedStream<A> eval = as.eval();
+        return eval.isEmpty() ?
             variant(0, g) :
-            variant(1, ca.cogen(as.head(), cogen(as.tail()._1(), g)));
+            variant(1, ca.cogen(eval.unsafeHead(), cogen(eval.unsafeTail(), g)));
       }
     };
   }

--- a/quickcheck/src/main/java/fj/test/Property.java
+++ b/quickcheck/src/main/java/fj/test/Property.java
@@ -402,12 +402,13 @@ public final class Property {
             return result.toOption().map(result1 -> p(a, result1.provenAsUnfalsified().addArg(arg(a, shrinks))));
           });
 
-          if (results.isEmpty())
-            return none();
-          else return results.find(this::failed).orSome(results::head);
+          return results.uncons(
+              none(),
+              (head, tail) -> Stream.cons(head, tail).find(this::failed).orSome(head)
+          );
         }
 
-        public boolean failed(final Option<P2<A, Result>> o) {
+        boolean failed(final Option<P2<A, Result>> o) {
           return o.isSome() && o.some()._2().failed();
         }
       }


### PR DESCRIPTION
 - by name: evaluated every time (default, fastest if not traversed
 multiple times);
 - lazy: haskell semantic: at most once evaluated;
 - weakly memoized (head and tail wrapped in a WeakReference).

Evaluation to weak head normal form (ie. for pattern matching equivalent code) is now properly trampolined (do not stack overflow).

This fix #330 and #304 (by making `iteratorStream` safe for reuse).

Still some work to do in `Tree` and `Zipper` to adapt code (WIP), for early review.