### PR TITLE
Basic JPMS (modules) support through 'Automatic-Module-Name'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ configure(subprojects.findAll { it.name != "props-core" }) {
         buildCommand 'org.eclipse.pde.ManifestBuilder'
         buildCommand 'org.eclipse.pde.SchemaBuilder'
       }
+      instruction 'Automatic-Module-Name', "functionaljava${project.name == 'core' ? '' : "-$project.name"}"
     }
 
     // Output MANIFEST.MF statically so eclipse can see it for plugin development

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ configure(subprojects.findAll { it.name != "props-core" }) {
             if(project.name != "core") {
                 instruction 'Require-Bundle', 'org.functionaljava;bundle-version="'+project.fjBaseVersion+'"'
             }
-            instruction 'Automatic-Module-Name', "functionaljava${project.name == 'core' ? '' : "-$project.name"}"
+            instruction 'Automatic-Module-Name', "functionaljava${project.name == 'core' ? '' : ".$project.name"}"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -169,9 +169,10 @@ configure(subprojects.findAll { it.name != "props-core" }) {
             instruction 'Signature-Version', project.fjVersion
             instruction 'Bundle-ActivationPolicy', 'lazy'
             instruction 'Bundle-Vendor', 'functionaljava.org'
-			if(project.name != "core") {
-				instruction 'Require-Bundle', 'org.functionaljava;bundle-version="'+project.fjBaseVersion+'"'
-			}
+            if(project.name != "core") {
+                instruction 'Require-Bundle', 'org.functionaljava;bundle-version="'+project.fjBaseVersion+'"'
+            }
+            instruction 'Automatic-Module-Name', "functionaljava${project.name == 'core' ? '' : "-$project.name"}"
         }
     }
 
@@ -181,7 +182,6 @@ configure(subprojects.findAll { it.name != "props-core" }) {
         buildCommand 'org.eclipse.pde.ManifestBuilder'
         buildCommand 'org.eclipse.pde.SchemaBuilder'
       }
-      instruction 'Automatic-Module-Name', "functionaljava${project.name == 'core' ? '' : "-$project.name"}"
     }
 
     // Output MANIFEST.MF statically so eclipse can see it for plugin development


### PR DESCRIPTION
Currently, having the 'functionaljava_1.8' jar on the classpath of a jvm version 9 or above is problematic since the module name automatically derived by either javac or the vm is broken. This P.R fixes this.

Whole modules declaration (module-info.java) should happen on the 5.x branch, I think.