### PR TITLE
Add fj.test.Gen.streamOf(Gen<A>).

### DIFF
--- a/quickcheck/src/main/java/fj/test/Gen.java
+++ b/quickcheck/src/main/java/fj/test/Gen.java
@@ -9,6 +9,7 @@ import fj.control.Trampoline;
 import fj.data.Array;
 import fj.data.List;
 import fj.data.Option;
+import fj.data.Stream;
 import fj.function.Effect1;
 
 import static fj.Bottom.error;
@@ -495,6 +496,18 @@ public final class Gen<A> {
    */
   public static <A> Gen<List<A>> listOf1(final Gen<A> g) {
     return listOf(g, 1);
+  }
+
+  /**
+   * Returns a generator of streams whose values come from the given generator.
+   *
+   * @param g   the generator to produce values from for the returned generator
+   * @param <A> the type of the generator
+   *
+   * @return A generator of streams whose values come from the given generator.
+   */
+  public static <A> Gen<Stream<A>> streamOf(final Gen<A> g) {
+    return gen(i -> r -> Stream.cons(g.gen(i, r), () -> streamOf(g).gen(i, r)));
   }
 
   /**

--- a/quickcheck/src/test/java/fj/test/GenTest.java
+++ b/quickcheck/src/test/java/fj/test/GenTest.java
@@ -1,16 +1,19 @@
 package fj.test;
 
 import fj.data.List;
+import fj.data.Stream;
 import fj.function.Effect1;
 import org.junit.Test;
 
 import static fj.Ord.charOrd;
 import static fj.data.List.list;
 import static fj.data.List.range;
-import static fj.test.Gen.selectionOf;
 import static fj.test.Gen.combinationOf;
-import static fj.test.Gen.wordOf;
 import static fj.test.Gen.permutationOf;
+import static fj.test.Gen.pickOne;
+import static fj.test.Gen.selectionOf;
+import static fj.test.Gen.streamOf;
+import static fj.test.Gen.wordOf;
 import static fj.test.Rand.standard;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -170,6 +173,15 @@ public final class GenTest {
   public void testWordOf_four() {
     Gen<List<Character>> instance = wordOf(4, AS);
     testPick(100, instance, actual -> {
+      assertEquals(4, actual.length());
+      assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
+    });
+  }
+
+  @Test
+  public void testStreamOf() {
+    final Gen<Stream<Character>> instance = streamOf(pickOne(AS));
+    testPick(100, instance.map(stream -> stream.take(4).toList()), actual -> {
       assertEquals(4, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
     });


### PR DESCRIPTION
It should return a generator of streams whose values come from the given generator; similar to fj.test.Gen.listOf(Gen<A>):

```java
public static <A> Gen<Stream<A>> streamOf(final Gen<A> g) {
  return gen(i -> r -> Stream.cons(g.gen(i, r), () -> streamOf(g).gen(i, r)));
}
```

Fixes #398.