### PR TITLE
Fixes #401. Add fj.test.Gen.sequence(Validation<E, Gen<A>>).

### DIFF
--- a/quickcheck/src/main/java/fj/test/Gen.java
+++ b/quickcheck/src/main/java/fj/test/Gen.java
@@ -10,6 +10,7 @@ import fj.data.Array;
 import fj.data.List;
 import fj.data.Option;
 import fj.data.Stream;
+import fj.data.Validation;
 import fj.function.Effect1;
 
 import static fj.Bottom.error;
@@ -317,6 +318,19 @@ public final class Gen<A> {
    */
   public static <A> Gen<List<A>> sequenceN(final int n, final Gen<A> g) {
     return sequence(replicate(n, g));
+  }
+
+  /**
+   * Transform a validation for a generator into a generator of validations: if the given validation is a failure, the
+   * generator produces that failure value; if the given validation is a success, the generator produces success values.
+   *
+   * @param gv  The validation for a generator.
+   * @param <A> the type of the value
+   * @param <E> the type of the failure
+   * @return if the given validation is a failure, the generator produces that failure value; if the given validation is a success, the generator produces success values.
+   */
+  public static <E, A> Gen<Validation<E, A>> sequence(final Validation<E, Gen<A>> gv) {
+    return gen(i -> r -> gv.map(g -> g.gen(i, r)));
   }
 
   /**

--- a/quickcheck/src/test/java/fj/test/GenTest.java
+++ b/quickcheck/src/test/java/fj/test/GenTest.java
@@ -1,17 +1,27 @@
 package fj.test;
 
+import fj.Equal;
 import fj.data.List;
+import fj.data.NonEmptyList;
+import fj.data.Option;
 import fj.data.Stream;
+import fj.data.Validation;
 import fj.function.Effect1;
 import org.junit.Test;
 
 import static fj.Ord.charOrd;
 import static fj.data.List.list;
 import static fj.data.List.range;
+import static fj.data.NonEmptyList.nel;
+import static fj.data.Option.somes;
+import static fj.data.Validation.fail;
+import static fj.data.Validation.success;
 import static fj.test.Gen.combinationOf;
+import static fj.test.Gen.listOf;
 import static fj.test.Gen.permutationOf;
 import static fj.test.Gen.pickOne;
 import static fj.test.Gen.selectionOf;
+import static fj.test.Gen.sequence;
 import static fj.test.Gen.streamOf;
 import static fj.test.Gen.wordOf;
 import static fj.test.Rand.standard;
@@ -185,6 +195,15 @@ public final class GenTest {
       assertEquals(4, actual.length());
       assertTrue(actual.forall(actualA -> AS.exists(a -> a.equals(actualA))));
     });
+  }
+
+  @Test
+  public void testSequenceValidation() {
+    final Gen<List<Validation<NonEmptyList<Exception>, Character>>> success = listOf(sequence(success(pickOne(AS))), 4);
+    testPick(100, success, list -> assertEquals(list.length(),somes(list.map(v -> Option.sequence(v.map(c -> AS.elementIndex(Equal.anyEqual(), c))))).length()));
+
+    final Gen<List<Validation<NonEmptyList<Exception>, Gen<Character>>>> failure = listOf(sequence(fail(nel(new Exception()))), 4);
+    testPick(100, failure, list -> assertTrue(list.forall(a -> a.isFail())));
   }
 
   private static <A> void testPick(int n, Gen<List<A>> instance, Effect1<List<A>> test) {


### PR DESCRIPTION
Fixes #401. Add fj.test.Gen.sequence(Validation<E, Gen<A>>).

It should transform a validation for a generator into a generator of validations: if the given validation is a failure, the generator produces that failure value; if the given validation is a success, the generator produces success values.

```
public static <E, A> Gen<Validation<E, A>> sequence(final Validation<E, Gen<A>> gv) {
    return gen(i -> r -> gv.map(g -> g.gen(i, r)));
}
```