### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
             reports.html.required = false
             reports.junitXml.required = false
         }
+	forkEvery = 100
     }
     apply plugin: "jacoco"
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,13 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 allprojects {
-
+    tasks.withType(Test).configureEach {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        if (!project.hasProperty("createReports")) {
+            reports.html.required = false
+            reports.junitXml.required = false
+        }
+    }
     apply plugin: "jacoco"
 
     jacoco {


### PR DESCRIPTION
[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution). Gradle can run multiple test cases in parallel by setting `maxParallelForks`.

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation). We can conditionally disable it by setting `reports.html.required = false; reports.junitXml.required = false`. If you need to generate reports, add `-PcreateReports` to the end of Gradle's build command line.

[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.



=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.