### PR TITLE
Add GitHub actions as CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - series/*
+  pull_request:
+    branches:
+      - series/*
+  workflow_dispatch: {}
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Execute Gradle build
+        run: ./gradlew build


### PR DESCRIPTION
As travis CI dies a slow death, it's a good idea to make the transition to GitHub actions

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
