### PR TITLE
Refactor Junit4 to Junit 5

### DIFF
--- a/consume/src/test/java/fj/EmptyTest.java
+++ b/consume/src/test/java/fj/EmptyTest.java
@@ -1,15 +1,15 @@
 package fj;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class EmptyTest {
 
-    @Ignore @Test
-    public void missing() {
-        Assert.fail("not implemented");
+  @Disabled
+  @Test
+  void missing() {
+    Assertions.fail("not implemented");
 
-    }
+  }
 }

--- a/core/src/test/java/fj/ClassTest.java
+++ b/core/src/test/java/fj/ClassTest.java
@@ -4,9 +4,10 @@ import fj.data.List;
 import fj.data.Natural;
 import fj.data.Option;
 import fj.data.Tree;
-import org.junit.Test;
 
 import java.lang.reflect.Type;
+
+import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -14,40 +15,40 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ClassTest {
-    @Test
-    public void testInheritance() {
-        Class<Natural> c = Class.clas(Natural.class);
-        List<Class<? super Natural>> l = c.inheritance();
-        assertThat(l.length(), is(3));
-    }
+  @Test
+  void testInheritance() {
+    Class<Natural> c = Class.clas(Natural.class);
+    List<Class<? super Natural>> l = c.inheritance();
+    assertThat(l.length(), is(3));
+  }
 
-    @Test
-    public void testClassParameters() {
-        Class<? extends Option> c = Class.clas(Option.none().getClass());
-        Tree<Type> cp = c.classParameters();
-        assertThat(cp.length(), is(1));
-    }
+  @Test
+  void testClassParameters() {
+    Class<? extends Option> c = Class.clas(Option.none().getClass());
+    Tree<Type> cp = c.classParameters();
+    assertThat(cp.length(), is(1));
+  }
 
-    @Test
-    public void testSuperclassParameters() {
-        Class<? extends Option> c = Class.clas(Option.none().getClass());
-        Tree<Type> cp = c.superclassParameters();
-        assertThat(cp.length(), is(2));
-    }
+  @Test
+  void testSuperclassParameters() {
+    Class<? extends Option> c = Class.clas(Option.none().getClass());
+    Tree<Type> cp = c.superclassParameters();
+    assertThat(cp.length(), is(2));
+  }
 
-    @Test
-    public void testInterfaceParameters() {
-        Class<? extends Option> c = Class.clas(Option.none().getClass());
-        List<Tree<Type>> l =c.interfaceParameters();
-        assertThat(l.length(), is(0));
-    }
+  @Test
+  void testInterfaceParameters() {
+    Class<? extends Option> c = Class.clas(Option.none().getClass());
+    List<Tree<Type>> l = c.interfaceParameters();
+    assertThat(l.length(), is(0));
+  }
 
-    @Test
-    public void testTypeParameterTree() {
-        Class<? extends Option> c = Class.clas(Option.none().getClass());
-        Collection<Type> coll = c.classParameters().toCollection();
-        for (Type t: coll) {
-            assertThat(Class.typeParameterTree(t).toString(), is("Tree(class fj.data.Option$None)"));
-        }
+  @Test
+  void testTypeParameterTree() {
+    Class<? extends Option> c = Class.clas(Option.none().getClass());
+    Collection<Type> coll = c.classParameters().toCollection();
+    for (Type t : coll) {
+      assertThat(Class.typeParameterTree(t).toString(), is("Tree(class fj.data.Option$None)"));
     }
+  }
 }

--- a/core/src/test/java/fj/DigitTest.java
+++ b/core/src/test/java/fj/DigitTest.java
@@ -1,30 +1,31 @@
 package fj;
 
 import fj.data.Option;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Array.range;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DigitTest {
-    @Test
-    public void testInteger() {
-        for (Integer i: range(0, 10)) {
-            assertThat(Digit.fromLong(i).toLong(), is(i.longValue()));
-        }
+  @Test
+  void testInteger() {
+    for (Integer i : range(0, 10)) {
+      assertThat(Digit.fromLong(i).toLong(), is(i.longValue()));
     }
+  }
 
-    @Test
-    public void testChar() {
-        for (Integer i: range(0, 10)) {
-            Character c = Character.forDigit(i, 10);
-            assertThat(Digit.fromChar(c).some().toChar(), is(c));
-        }
+  @Test
+  void testChar() {
+    for (Integer i : range(0, 10)) {
+      Character c = Character.forDigit(i, 10);
+      assertThat(Digit.fromChar(c).some().toChar(), is(c));
     }
+  }
 
-    @Test
-    public void testCharNone() {
-        assertThat(Digit.fromChar('x'), is(Option.none()));
-    }
+  @Test
+  void testCharNone() {
+    assertThat(Digit.fromChar('x'), is(Option.none()));
+  }
 }

--- a/core/src/test/java/fj/EqualTest.java
+++ b/core/src/test/java/fj/EqualTest.java
@@ -1,13 +1,13 @@
 package fj;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class EqualTest {
   @Test
-  public void contramapShouldWork() {
+  void contramapShouldWork() {
     Equal<String> equalByLength = Equal.contramap(String::length, Equal.intEqual);
 
     assertThat(equalByLength.eq("str1", "str2"), is(true));
@@ -15,9 +15,9 @@ public class EqualTest {
   }
 
   @Test
-  public void thenShouldWork() {
+  void thenShouldWork() {
     Equal<String> equalByLengthThenLastDigit = Equal.on(String::length, Equal.intEqual)
-                                                    .then(s -> s.charAt(s.length() - 1), Equal.charEqual).equal();
+        .then(s -> s.charAt(s.length() - 1), Equal.charEqual).equal();
 
     assertThat(equalByLengthThenLastDigit.eq("str1", "spr1"), is(true));
     assertThat(equalByLengthThenLastDigit.eq("str1", "str2"), is(false));

--- a/core/src/test/java/fj/FFunctionsTest.java
+++ b/core/src/test/java/fj/FFunctionsTest.java
@@ -2,29 +2,30 @@ package fj;
 
 import fj.data.Tree;
 import fj.data.TreeZipper;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FFunctionsTest {
 
-    @Test
-    public void testTreeK() {
-        final Tree<Integer> t1 = Function.<Integer>identity().treeK().f(1);
-        final Tree<Integer> t2 = Function.<Integer>identity().treeK().f(2);
-        F<Integer, Integer> f = i -> i + 1;
-        F<Integer, Integer> g = i -> i * 1;
-        assertThat(f.mapTree().f(t1),
-                is(g.mapTree().f(t2)));
-    }
+  @Test
+  void testTreeK() {
+    final Tree<Integer> t1 = Function.<Integer>identity().treeK().f(1);
+    final Tree<Integer> t2 = Function.<Integer>identity().treeK().f(2);
+    F<Integer, Integer> f = i -> i + 1;
+    F<Integer, Integer> g = i -> i * 1;
+    assertThat(f.mapTree().f(t1),
+        is(g.mapTree().f(t2)));
+  }
 
-    @Test
-    public void testTreeZipperK() {
-        final TreeZipper<Integer> tz1 = Function.<Integer>identity().treeZipperK().f(1);
-        final TreeZipper<Integer> tz2 = Function.<Integer>identity().treeZipperK().f(2);
-        F<Integer, Integer> f = i -> i + 1;
-        F<Integer, Integer> g = i -> i * 1;
-        assertThat(f.mapTreeZipper().f(tz1),
-                is(g.mapTreeZipper().f(tz2)));
-    }
+  @Test
+  void testTreeZipperK() {
+    final TreeZipper<Integer> tz1 = Function.<Integer>identity().treeZipperK().f(1);
+    final TreeZipper<Integer> tz2 = Function.<Integer>identity().treeZipperK().f(2);
+    F<Integer, Integer> f = i -> i + 1;
+    F<Integer, Integer> g = i -> i * 1;
+    assertThat(f.mapTreeZipper().f(tz1),
+        is(g.mapTreeZipper().f(tz2)));
+  }
 }

--- a/core/src/test/java/fj/MonoidTest.java
+++ b/core/src/test/java/fj/MonoidTest.java
@@ -4,7 +4,8 @@ import fj.data.Enumerator;
 import fj.data.Option;
 import fj.data.Set;
 import fj.data.Stream;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Option.some;
 import static org.hamcrest.core.Is.is;
@@ -13,14 +14,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class MonoidTest {
 
   @Test
-  public void lifted_sum_of_two_numbers() {
+  void lifted_sum_of_two_numbers() {
     Monoid<Option<Integer>> optionMonoid = Semigroup.intAdditionSemigroup.lift();
     assertThat(optionMonoid.sum(some(3), some(5)), is(some(8)));
     assertThat(optionMonoid.sumLeft(Stream.arrayStream(some(3), some(5))), is(some(8)));
   }
 
   @Test
-  public void intersection_monoid_test() {
+  void intersection_monoid_test() {
     Bounded<Integer> integersBounded = Bounded.bounded(0, 10);
     Monoid<Set<Integer>> intersectionMonoid = Monoid.setIntersectionMonoid(integersBounded, Enumerator.intEnumerator);
     Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
@@ -30,7 +31,7 @@ public class MonoidTest {
   }
 
   @Test
-  public void union_monoid_test() {
+  void union_monoid_test() {
     Monoid<Set<Integer>> unionMonoid = Monoid.setMonoid(Ord.intOrd);
     Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
     Set<Integer> second = Set.set(Ord.intOrd, 3, 4, 5, 6);
@@ -39,7 +40,7 @@ public class MonoidTest {
   }
 
   @Test
-  public void intersection_monoid_zero_test() {
+  void intersection_monoid_zero_test() {
     Bounded<Integer> integersBounded = Bounded.bounded(0, 10);
     Monoid<Set<Integer>> monoid = Monoid.setIntersectionMonoid(integersBounded, Enumerator.intEnumerator);
     Set<Integer> set = Set.set(Ord.intOrd, 7, 8, 9, 10);
@@ -48,7 +49,7 @@ public class MonoidTest {
   }
 
   @Test
-  public void union_monoid_zero_test() {
+  void union_monoid_zero_test() {
     Monoid<Set<Integer>> monoid = Monoid.setMonoid(Ord.intOrd);
     Set<Integer> set = Set.set(Ord.intOrd, 1, 2, 3, 4);
     Set<Integer> zero = monoid.zero();

--- a/core/src/test/java/fj/OrdTest.java
+++ b/core/src/test/java/fj/OrdTest.java
@@ -1,6 +1,6 @@
 package fj;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class OrdTest {
 
   @Test
-  public void isGreaterThan() {
+  void isGreaterThan() {
     F<Long, Boolean> pred = Ord.longOrd.isGreaterThan(1L);
 
     assertThat(pred.f(0L), is(false));
@@ -17,7 +17,7 @@ public class OrdTest {
   }
 
   @Test
-  public void isLessThan() {
+  void isLessThan() {
     F<Long, Boolean> pred = Ord.longOrd.isLessThan(1L);
 
     assertThat(pred.f(0L), is(true));
@@ -26,7 +26,7 @@ public class OrdTest {
   }
 
   @Test
-  public void contramapShouldWork() {
+  void contramapShouldWork() {
     Ord<String> lengthOrd = Ord.contramap(String::length, Ord.intOrd);
 
     assertThat(lengthOrd.compare("str", "rts"), is(Ordering.EQ));
@@ -34,9 +34,9 @@ public class OrdTest {
   }
 
   @Test
-  public void thenShouldWork() {
+  void thenShouldWork() {
     Ord<String> lengthThenLastDigitOrd = Ord.on(String::length, Ord.intOrd)
-                                            .then(s -> s.charAt(s.length() - 1), Ord.charOrd).ord();
+        .then(s -> s.charAt(s.length() - 1), Ord.charOrd).ord();
 
     assertThat(lengthThenLastDigitOrd.compare("str", "dyr"), is(Ordering.EQ));
     assertThat(lengthThenLastDigitOrd.compare("stt", "str"), is(Ordering.GT));

--- a/core/src/test/java/fj/OrderingTest.java
+++ b/core/src/test/java/fj/OrderingTest.java
@@ -2,7 +2,7 @@ package fj;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.core.Is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.Ordering.EQ;
 import static fj.Ordering.GT;
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class OrderingTest {
 
   @Test
-  public void reverse() throws Exception {
+  void reverse() throws Exception {
     assertThat(GT.reverse(), is(LT));
     assertThat(LT.reverse(), is(GT));
     assertThat(EQ.reverse(), is(EQ));

--- a/core/src/test/java/fj/P1Test.java
+++ b/core/src/test/java/fj/P1Test.java
@@ -1,6 +1,7 @@
 package fj;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class P1Test {
 
   @Test
-  public void bug105() throws Exception {
+  void bug105() throws Exception {
     final P1<String> p1 = P.weakMemo(() -> "Foo");
     final AtomicInteger nullCounter = new AtomicInteger();
     ExecutorService executorService = Executors.newCachedThreadPool();
@@ -26,14 +27,14 @@ public final class P1Test {
     executorService.shutdown();
     executorService.awaitTermination(10, TimeUnit.DAYS);
 
-    org.junit.Assert.assertEquals("Race condition in P1.memo()", 0, nullCounter.get());
+    Assertions.assertEquals(0, nullCounter.get(), "Race condition in P1.memo()");
   }
-  
+
   @Test
-  public void bug122() throws Exception {
+  void bug122() throws Exception {
     final P1<Integer> p1a = P.lazy(() -> 1);
     final P1<Integer> p1b = P.lazy(() -> 1);
 
-    org.junit.Assert.assertTrue(p1a + " and " + p1b + " should be equal by Object.equals", p1a.equals(p1b));
+    Assertions.assertTrue(p1a.equals(p1b), p1a + " and " + p1b + " should be equal by Object.equals");
   }
 }

--- a/core/src/test/java/fj/P2Test.java
+++ b/core/src/test/java/fj/P2Test.java
@@ -1,14 +1,14 @@
 package fj;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class P2Test {
 
-	@Test
-	public void testToString() {
-		String s = P.p(1, 2).toString();
-		Assert.assertTrue(s.equals("(1,2)"));
-	}
+  @Test
+  void testToString() {
+    String s = P.p(1, 2).toString();
+    Assertions.assertTrue(s.equals("(1,2)"));
+  }
 
 }

--- a/core/src/test/java/fj/PTest.java
+++ b/core/src/test/java/fj/PTest.java
@@ -1,159 +1,159 @@
 package fj;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.Function.identity;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PTest {
-    @Test
-    public void testPF(){
-        final F<Integer, P1<Integer>> p1f = P.p1();
-        final P1<Integer> p1 = p1f.f(1);
-        F<Integer, F<Integer, P2<Integer, Integer>>> p2f = P.p2();
-        final P2<Integer, Integer> p2 = p2f.f(1).f(2);
-        assertThat(P2.<Integer,Integer>__1().f(p2), is(P1.<Integer>__1().f(p1)));
-        final F<Integer, F<Integer, F<Integer, P3<Integer, Integer, Integer>>>> p3f = P.p3();
-        final P3<Integer, Integer, Integer> p3 = p3f.f(1).f(2).f(3);
-        assertThat(P3.<Integer,Integer, Integer>__1().f(p3), is(P2.<Integer,Integer>__1().f(p2)));
-        assertThat(P3.<Integer,Integer, Integer>__2().f(p3), is(P2.<Integer,Integer>__2().f(p2)));
-        final F<Integer, F<Integer, F<Integer, F<Integer, P4<Integer, Integer, Integer, Integer>>>>> p4f = P.p4();
-        final P4<Integer, Integer, Integer, Integer> p4 = p4f.f(1).f(2).f(3).f(4);
-        assertThat(P4.<Integer,Integer,Integer,Integer>__1().f(p4), is(P3.<Integer,Integer,Integer>__1().f(p3)));
-        assertThat(P4.<Integer,Integer,Integer,Integer>__2().f(p4), is(P3.<Integer,Integer,Integer>__2().f(p3)));
-        assertThat(P4.<Integer,Integer,Integer,Integer>__3().f(p4), is(P3.<Integer,Integer,Integer>__3().f(p3)));
-        final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, P5<Integer, Integer, Integer, Integer, Integer>>>>>> p5f = P.p5();
-        final P5<Integer, Integer, Integer, Integer, Integer> p5 = p5f.f(1).f(2).f(3).f(4).f(5);
-        assertThat(P5.<Integer,Integer,Integer,Integer,Integer>__1().f(p5), is(P4.<Integer,Integer,Integer,Integer>__1().f(p4)));
-        assertThat(P5.<Integer,Integer,Integer,Integer,Integer>__2().f(p5), is(P4.<Integer,Integer,Integer,Integer>__2().f(p4)));
-        assertThat(P5.<Integer,Integer,Integer,Integer,Integer>__3().f(p5), is(P4.<Integer,Integer,Integer,Integer>__3().f(p4)));
-        assertThat(P5.<Integer,Integer,Integer,Integer,Integer>__4().f(p5), is(P4.<Integer,Integer,Integer,Integer>__4().f(p4)));
-        final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
-                P6<Integer, Integer, Integer, Integer, Integer, Integer>>>>>>> p6f = P.p6();
-        final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = p6f.f(1).f(2).f(3).f(4).f(5).f(6);
-        assertThat(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__1().f(p6),
-                is(P5.<Integer,Integer,Integer,Integer,Integer>__1().f(p5)));
-        assertThat(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__2().f(p6),
-                is(P5.<Integer,Integer,Integer,Integer,Integer>__2().f(p5)));
-        assertThat(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__3().f(p6),
-                is(P5.<Integer,Integer,Integer,Integer,Integer>__3().f(p5)));
-        assertThat(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__4().f(p6),
-                is(P5.<Integer,Integer,Integer,Integer,Integer>__4().f(p5)));
-        assertThat(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__5().f(p6),
-                is(P5.<Integer,Integer,Integer,Integer,Integer>__5().f(p5)));
-        final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
-                P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>>>>>>>> p7f = P.p7();
-        final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 =
-                p7f.f(1).f(2).f(3).f(4).f(5).f(6).f(7);
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__1().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__1().f(p6)));
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__2().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__2().f(p6)));
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__3().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__3().f(p6)));
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__4().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__4().f(p6)));
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__5().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__5().f(p6)));
-        assertThat(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__6().f(p7),
-                is(P6.<Integer,Integer,Integer,Integer,Integer,Integer>__6().f(p6)));
-        final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
-                F<Integer, F<Integer, P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>>>>>>>>> p8f = P.p8();
-        final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 =
-                p8f.f(1).f(2).f(3).f(4).f(5).f(6).f(7).f(8);
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__1().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__1().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__2().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__2().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__3().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__3().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__4().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__4().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__5().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__5().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__6().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__6().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__7().f(p8),
-                is(P7.<Integer,Integer,Integer,Integer,Integer,Integer,Integer>__7().f(p7)));
-        assertThat(P8.<Integer,Integer,Integer,Integer,Integer,Integer,Integer,Integer>__8().f(p8), is(8));
-    }
+  @Test
+  void testPF() {
+    final F<Integer, P1<Integer>> p1f = P.p1();
+    final P1<Integer> p1 = p1f.f(1);
+    F<Integer, F<Integer, P2<Integer, Integer>>> p2f = P.p2();
+    final P2<Integer, Integer> p2 = p2f.f(1).f(2);
+    assertThat(P2.<Integer, Integer>__1().f(p2), is(P1.<Integer>__1().f(p1)));
+    final F<Integer, F<Integer, F<Integer, P3<Integer, Integer, Integer>>>> p3f = P.p3();
+    final P3<Integer, Integer, Integer> p3 = p3f.f(1).f(2).f(3);
+    assertThat(P3.<Integer, Integer, Integer>__1().f(p3), is(P2.<Integer, Integer>__1().f(p2)));
+    assertThat(P3.<Integer, Integer, Integer>__2().f(p3), is(P2.<Integer, Integer>__2().f(p2)));
+    final F<Integer, F<Integer, F<Integer, F<Integer, P4<Integer, Integer, Integer, Integer>>>>> p4f = P.p4();
+    final P4<Integer, Integer, Integer, Integer> p4 = p4f.f(1).f(2).f(3).f(4);
+    assertThat(P4.<Integer, Integer, Integer, Integer>__1().f(p4), is(P3.<Integer, Integer, Integer>__1().f(p3)));
+    assertThat(P4.<Integer, Integer, Integer, Integer>__2().f(p4), is(P3.<Integer, Integer, Integer>__2().f(p3)));
+    assertThat(P4.<Integer, Integer, Integer, Integer>__3().f(p4), is(P3.<Integer, Integer, Integer>__3().f(p3)));
+    final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, P5<Integer, Integer, Integer, Integer, Integer>>>>>> p5f = P.p5();
+    final P5<Integer, Integer, Integer, Integer, Integer> p5 = p5f.f(1).f(2).f(3).f(4).f(5);
+    assertThat(P5.<Integer, Integer, Integer, Integer, Integer>__1().f(p5), is(P4.<Integer, Integer, Integer, Integer>__1().f(p4)));
+    assertThat(P5.<Integer, Integer, Integer, Integer, Integer>__2().f(p5), is(P4.<Integer, Integer, Integer, Integer>__2().f(p4)));
+    assertThat(P5.<Integer, Integer, Integer, Integer, Integer>__3().f(p5), is(P4.<Integer, Integer, Integer, Integer>__3().f(p4)));
+    assertThat(P5.<Integer, Integer, Integer, Integer, Integer>__4().f(p5), is(P4.<Integer, Integer, Integer, Integer>__4().f(p4)));
+    final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
+        P6<Integer, Integer, Integer, Integer, Integer, Integer>>>>>>> p6f = P.p6();
+    final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = p6f.f(1).f(2).f(3).f(4).f(5).f(6);
+    assertThat(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__1().f(p6),
+        is(P5.<Integer, Integer, Integer, Integer, Integer>__1().f(p5)));
+    assertThat(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__2().f(p6),
+        is(P5.<Integer, Integer, Integer, Integer, Integer>__2().f(p5)));
+    assertThat(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__3().f(p6),
+        is(P5.<Integer, Integer, Integer, Integer, Integer>__3().f(p5)));
+    assertThat(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__4().f(p6),
+        is(P5.<Integer, Integer, Integer, Integer, Integer>__4().f(p5)));
+    assertThat(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__5().f(p6),
+        is(P5.<Integer, Integer, Integer, Integer, Integer>__5().f(p5)));
+    final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
+        P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>>>>>>>> p7f = P.p7();
+    final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 =
+        p7f.f(1).f(2).f(3).f(4).f(5).f(6).f(7);
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__1().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__1().f(p6)));
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__2().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__2().f(p6)));
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__3().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__3().f(p6)));
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__4().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__4().f(p6)));
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__5().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__5().f(p6)));
+    assertThat(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__6().f(p7),
+        is(P6.<Integer, Integer, Integer, Integer, Integer, Integer>__6().f(p6)));
+    final F<Integer, F<Integer, F<Integer, F<Integer, F<Integer, F<Integer,
+        F<Integer, F<Integer, P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>>>>>>>>> p8f = P.p8();
+    final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 =
+        p8f.f(1).f(2).f(3).f(4).f(5).f(6).f(7).f(8);
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__1().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__1().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__2().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__2().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__3().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__3().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__4().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__4().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__5().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__5().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__6().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__6().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__7().f(p8),
+        is(P7.<Integer, Integer, Integer, Integer, Integer, Integer, Integer>__7().f(p7)));
+    assertThat(P8.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>__8().f(p8), is(8));
+  }
 
-    @Test
-    public void testPProject1() {
-        final P1<Integer> p1 = P.p(1);
-        assertThat(p1.map(identity()), is(p1));
-    }
+  @Test
+  void testPProject1() {
+    final P1<Integer> p1 = P.p(1);
+    assertThat(p1.map(identity()), is(p1));
+  }
 
-    @Test
-    public void testPProject2() {
-        final P2<Integer, Integer> p2 = P.p(1, 2);
-        assertThat(p2.map1(identity()), is(p2));
-        assertThat(p2.map2(identity()), is(p2));
-    }
+  @Test
+  void testPProject2() {
+    final P2<Integer, Integer> p2 = P.p(1, 2);
+    assertThat(p2.map1(identity()), is(p2));
+    assertThat(p2.map2(identity()), is(p2));
+  }
 
-    @Test
-    public void testPProject3() {
-        final P3<Integer, Integer, Integer> p3 = P.p(1, 2, 3);
-        assertThat(p3.map1(identity()), is(p3));
-        assertThat(p3.map2(identity()), is(p3));
-        assertThat(p3.map3(identity()), is(p3));
-    }
+  @Test
+  void testPProject3() {
+    final P3<Integer, Integer, Integer> p3 = P.p(1, 2, 3);
+    assertThat(p3.map1(identity()), is(p3));
+    assertThat(p3.map2(identity()), is(p3));
+    assertThat(p3.map3(identity()), is(p3));
+  }
 
-    @Test
-    public void testPProject4() {
-        final P4<Integer, Integer, Integer, Integer> p4 = P.p(1, 2, 3, 4);
-        assertThat(p4.map1(identity()), is(p4));
-        assertThat(p4.map2(identity()), is(p4));
-        assertThat(p4.map3(identity()), is(p4));
-        assertThat(p4.map4(identity()), is(p4));
-    }
+  @Test
+  void testPProject4() {
+    final P4<Integer, Integer, Integer, Integer> p4 = P.p(1, 2, 3, 4);
+    assertThat(p4.map1(identity()), is(p4));
+    assertThat(p4.map2(identity()), is(p4));
+    assertThat(p4.map3(identity()), is(p4));
+    assertThat(p4.map4(identity()), is(p4));
+  }
 
-    @Test
-    public void testPProject5() {
-        final P5<Integer, Integer, Integer, Integer, Integer> p5 = P.p(1, 2, 3, 4, 5);
-        assertThat(p5.map1(identity()), is(p5));
-        assertThat(p5.map2(identity()), is(p5));
-        assertThat(p5.map3(identity()), is(p5));
-        assertThat(p5.map4(identity()), is(p5));
-        assertThat(p5.map5(identity()), is(p5));
-    }
+  @Test
+  void testPProject5() {
+    final P5<Integer, Integer, Integer, Integer, Integer> p5 = P.p(1, 2, 3, 4, 5);
+    assertThat(p5.map1(identity()), is(p5));
+    assertThat(p5.map2(identity()), is(p5));
+    assertThat(p5.map3(identity()), is(p5));
+    assertThat(p5.map4(identity()), is(p5));
+    assertThat(p5.map5(identity()), is(p5));
+  }
 
-    @Test
-    public void testPProject6() {
-        final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = P.p(1, 2, 3, 4, 5, 6);
-        assertThat(p6.map1(identity()), is(p6));
-        assertThat(p6.map2(identity()), is(p6));
-        assertThat(p6.map3(identity()), is(p6));
-        assertThat(p6.map4(identity()), is(p6));
-        assertThat(p6.map5(identity()), is(p6));
-        assertThat(p6.map6(identity()), is(p6));
-    }
+  @Test
+  void testPProject6() {
+    final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = P.p(1, 2, 3, 4, 5, 6);
+    assertThat(p6.map1(identity()), is(p6));
+    assertThat(p6.map2(identity()), is(p6));
+    assertThat(p6.map3(identity()), is(p6));
+    assertThat(p6.map4(identity()), is(p6));
+    assertThat(p6.map5(identity()), is(p6));
+    assertThat(p6.map6(identity()), is(p6));
+  }
 
-    @Test
-    public void testPProject7() {
-        final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 =
-                P.p(1, 2, 3, 4, 5, 6, 7);
-        assertThat(p7.map1(identity()), is(p7));
-        assertThat(p7.map2(identity()), is(p7));
-        assertThat(p7.map3(identity()), is(p7));
-        assertThat(p7.map4(identity()), is(p7));
-        assertThat(p7.map5(identity()), is(p7));
-        assertThat(p7.map6(identity()), is(p7));
-        assertThat(p7.map7(identity()), is(p7));
-    }
+  @Test
+  void testPProject7() {
+    final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 =
+        P.p(1, 2, 3, 4, 5, 6, 7);
+    assertThat(p7.map1(identity()), is(p7));
+    assertThat(p7.map2(identity()), is(p7));
+    assertThat(p7.map3(identity()), is(p7));
+    assertThat(p7.map4(identity()), is(p7));
+    assertThat(p7.map5(identity()), is(p7));
+    assertThat(p7.map6(identity()), is(p7));
+    assertThat(p7.map7(identity()), is(p7));
+  }
 
-    @Test
-    public void testPProject8() {
-        final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 =
-                P.p(1, 2, 3, 4, 5, 6, 7, 8);
-        assertThat(p8.map1(identity()), is(p8));
-        assertThat(p8.map2(identity()), is(p8));
-        assertThat(p8.map3(identity()), is(p8));
-        assertThat(p8.map4(identity()), is(p8));
-        assertThat(p8.map5(identity()), is(p8));
-        assertThat(p8.map6(identity()), is(p8));
-        assertThat(p8.map7(identity()), is(p8));
-        assertThat(p8.map8(identity()), is(p8));
-    }
+  @Test
+  void testPProject8() {
+    final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 =
+        P.p(1, 2, 3, 4, 5, 6, 7, 8);
+    assertThat(p8.map1(identity()), is(p8));
+    assertThat(p8.map2(identity()), is(p8));
+    assertThat(p8.map3(identity()), is(p8));
+    assertThat(p8.map4(identity()), is(p8));
+    assertThat(p8.map5(identity()), is(p8));
+    assertThat(p8.map6(identity()), is(p8));
+    assertThat(p8.map7(identity()), is(p8));
+    assertThat(p8.map8(identity()), is(p8));
+  }
 }

--- a/core/src/test/java/fj/SemigroupTest.java
+++ b/core/src/test/java/fj/SemigroupTest.java
@@ -1,26 +1,27 @@
 package fj;
 
 import fj.data.Set;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SemigroupTest {
 
-    @Test
-    public void intersection_semigroup_test() {
-        Semigroup<Set<Integer>> intersectionSemigroup = Semigroup.setIntersectionSemigroup();
-        Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
-        Set<Integer> second = Set.set(Ord.intOrd, 3, 4, 5, 6);
-        assertThat(intersectionSemigroup.sum(first, second), is(Set.set(Ord.intOrd, 3, 4)));
-    }
+  @Test
+  void intersection_semigroup_test() {
+    Semigroup<Set<Integer>> intersectionSemigroup = Semigroup.setIntersectionSemigroup();
+    Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
+    Set<Integer> second = Set.set(Ord.intOrd, 3, 4, 5, 6);
+    assertThat(intersectionSemigroup.sum(first, second), is(Set.set(Ord.intOrd, 3, 4)));
+  }
 
-    @Test
-    public void union_semigroup_test() {
-        Semigroup<Set<Integer>> unionSemigroup = Semigroup.setSemigroup();
-        Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
-        Set<Integer> second = Set.set(Ord.intOrd, 3, 4, 5, 6);
-        assertThat(unionSemigroup.sum(first, second), is(Set.set(Ord.intOrd, 1, 2, 3, 4, 5, 6)));
-    }
+  @Test
+  void union_semigroup_test() {
+    Semigroup<Set<Integer>> unionSemigroup = Semigroup.setSemigroup();
+    Set<Integer> first = Set.set(Ord.intOrd, 1, 2, 3, 4);
+    Set<Integer> second = Set.set(Ord.intOrd, 3, 4, 5, 6);
+    assertThat(unionSemigroup.sum(first, second), is(Set.set(Ord.intOrd, 1, 2, 3, 4, 5, 6)));
+  }
 }

--- a/core/src/test/java/fj/ShowTest.java
+++ b/core/src/test/java/fj/ShowTest.java
@@ -1,16 +1,18 @@
 package fj;
 
 import fj.data.Array;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Array.array;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShowTest {
-    @Test
-    public void arrayShow() {
-        Array<Integer> a = array(3, 5, 7);
-        String s = Show.arrayShow(Show.intShow).showS(a);
-        assertTrue(s.equals("Array(3,5,7)"));
-    }
+  @Test
+  void arrayShow() {
+    Array<Integer> a = array(3, 5, 7);
+    String s = Show.arrayShow(Show.intShow).showS(a);
+    assertTrue(s.equals("Array(3,5,7)"));
+  }
 }

--- a/core/src/test/java/fj/TryEffectTest.java
+++ b/core/src/test/java/fj/TryEffectTest.java
@@ -3,78 +3,79 @@ package fj;
 import fj.data.Validation;
 import fj.function.TryEffect0;
 import fj.function.TryEffect1;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TryEffectTest {
 
-    @Test
-    public void testTryEffect0Success() {
-        F<TryEffect0<TryEffectException>, Validation<TryEffectException, Unit>> f = TryEffect.f(TryEffect0::f);
-        Validation<TryEffectException, Unit> v = f.f(new AlwaysSucceed0());
-        assertThat(v.isSuccess(), is(true));
-        assertThat(v.success(), is(Unit.unit()));
-    }
+  @Test
+  void testTryEffect0Success() {
+    F<TryEffect0<TryEffectException>, Validation<TryEffectException, Unit>> f = TryEffect.f(TryEffect0::f);
+    Validation<TryEffectException, Unit> v = f.f(new AlwaysSucceed0());
+    assertThat(v.isSuccess(), is(true));
+    assertThat(v.success(), is(Unit.unit()));
+  }
 
-    @Test
-    public void testTryEffect0Fail() {
-        F<TryEffect0<TryEffectException>, Validation<TryEffectException, Unit>> f = TryEffect.f(TryEffect0::f);
-        Validation<TryEffectException, Unit> v = f.f(new AlwaysFail0());
-        assertThat(v.isFail(), is(true));
-        assertThat(v.fail(), is(new TryEffectException()));
-    }
+  @Test
+  void testTryEffect0Fail() {
+    F<TryEffect0<TryEffectException>, Validation<TryEffectException, Unit>> f = TryEffect.f(TryEffect0::f);
+    Validation<TryEffectException, Unit> v = f.f(new AlwaysFail0());
+    assertThat(v.isFail(), is(true));
+    assertThat(v.fail(), is(new TryEffectException()));
+  }
 
-    @Test
-    public void testTryEffect1Success() {
-        F2<TryEffect1<Integer, TryEffectException>, Integer, Validation<TryEffectException, Unit>> f =
-                TryEffect.f(TryEffect1<Integer, TryEffectException>::f);
-        Validation<TryEffectException, Unit> v = f.f(new AlwaysSucceed1(), 1);
-        assertThat(v.isSuccess(), is(true));
-        assertThat(v.success(), is(Unit.unit()));
-    }
+  @Test
+  void testTryEffect1Success() {
+    F2<TryEffect1<Integer, TryEffectException>, Integer, Validation<TryEffectException, Unit>> f =
+        TryEffect.f(TryEffect1<Integer, TryEffectException>::f);
+    Validation<TryEffectException, Unit> v = f.f(new AlwaysSucceed1(), 1);
+    assertThat(v.isSuccess(), is(true));
+    assertThat(v.success(), is(Unit.unit()));
+  }
 
-    @Test
-    public void testTryEffect1Fail() {
-        F2<TryEffect1<Integer, TryEffectException>, Integer, Validation<TryEffectException, Unit>> f =
-                TryEffect.f(TryEffect1<Integer, TryEffectException>::f);
-        Validation<TryEffectException, Unit> v = f.f(new AlwaysFail1(), 1);
-        assertThat(v.isFail(), is(true));
-        assertThat(v.fail(), is(new TryEffectException()));
-    }
+  @Test
+  void testTryEffect1Fail() {
+    F2<TryEffect1<Integer, TryEffectException>, Integer, Validation<TryEffectException, Unit>> f =
+        TryEffect.f(TryEffect1<Integer, TryEffectException>::f);
+    Validation<TryEffectException, Unit> v = f.f(new AlwaysFail1(), 1);
+    assertThat(v.isFail(), is(true));
+    assertThat(v.fail(), is(new TryEffectException()));
+  }
 
-    class AlwaysSucceed0 implements TryEffect0<TryEffectException> {
-        @Override
-        public void f() throws TryEffectException {
-            // SUCCESS
-        }
+  class AlwaysSucceed0 implements TryEffect0<TryEffectException> {
+    @Override
+    public void f() throws TryEffectException {
+      // SUCCESS
     }
+  }
 
-    class AlwaysSucceed1 implements TryEffect1<Integer, TryEffectException> {
-        @Override
-        public void f(Integer i) throws TryEffectException {
-            // SUCCESS;
-        }
+  class AlwaysSucceed1 implements TryEffect1<Integer, TryEffectException> {
+    @Override
+    public void f(Integer i) throws TryEffectException {
+      // SUCCESS;
     }
+  }
 
-    class AlwaysFail0 implements TryEffect0<TryEffectException> {
-        @Override
-        public void f() throws TryEffectException {
-            throw new TryEffectException();
-        }
+  class AlwaysFail0 implements TryEffect0<TryEffectException> {
+    @Override
+    public void f() throws TryEffectException {
+      throw new TryEffectException();
     }
+  }
 
-    class AlwaysFail1 implements TryEffect1<Integer, TryEffectException> {
-        @Override
-        public void f(Integer i) throws TryEffectException {
-            throw new TryEffectException();
-        }
+  class AlwaysFail1 implements TryEffect1<Integer, TryEffectException> {
+    @Override
+    public void f(Integer i) throws TryEffectException {
+      throw new TryEffectException();
     }
+  }
 
-    class TryEffectException extends Exception {
-        @Override
-        public boolean equals (Object obj) {
-            return (obj instanceof TryEffectException);
-        }
+  class TryEffectException extends Exception {
+    @Override
+    public boolean equals(Object obj) {
+      return (obj instanceof TryEffectException);
     }
+  }
 }

--- a/core/src/test/java/fj/TryTest.java
+++ b/core/src/test/java/fj/TryTest.java
@@ -2,49 +2,50 @@ package fj;
 
 import fj.data.Validation;
 import fj.function.Try0;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TryTest {
 
-    @Test
-    public void testTrySuccess() {
-        F<Try0<Integer, TryException>, Validation<TryException, Integer>> f =
-                Try.f(Try0::f);
-        Validation<TryException, Integer> v = f.f(new AlwaysSucceed());
-        assertThat(v.isSuccess(), is(true));
-        assertThat(v.success(), is(99));
-    }
+  @Test
+  void testTrySuccess() {
+    F<Try0<Integer, TryException>, Validation<TryException, Integer>> f =
+        Try.f(Try0::f);
+    Validation<TryException, Integer> v = f.f(new AlwaysSucceed());
+    assertThat(v.isSuccess(), is(true));
+    assertThat(v.success(), is(99));
+  }
 
-    @Test
-    public void testTryFail() {
-        F<Try0<Integer, TryException>, Validation<TryException, Integer>> f =
-                Try.f(Try0::f);
-        Validation<TryException, Integer> v = f.f(new AlwaysFail());
-        assertThat(v.isFail(), is(true));
-        assertThat(v.fail(), is(new TryException()));
-    }
+  @Test
+  void testTryFail() {
+    F<Try0<Integer, TryException>, Validation<TryException, Integer>> f =
+        Try.f(Try0::f);
+    Validation<TryException, Integer> v = f.f(new AlwaysFail());
+    assertThat(v.isFail(), is(true));
+    assertThat(v.fail(), is(new TryException()));
+  }
 
-    class AlwaysSucceed implements Try0<Integer, TryException> {
-        @Override
-        public Integer f() throws TryException {
-            return 99;
-        }
+  class AlwaysSucceed implements Try0<Integer, TryException> {
+    @Override
+    public Integer f() throws TryException {
+      return 99;
     }
+  }
 
-    class AlwaysFail implements Try0<Integer, TryException> {
-        @Override
-        public Integer f() throws TryException {
-            throw new TryException();
-        }
+  class AlwaysFail implements Try0<Integer, TryException> {
+    @Override
+    public Integer f() throws TryException {
+      throw new TryException();
     }
+  }
 
-    class TryException extends Exception {
-        @Override
-        public boolean equals (Object obj) {
-            return (obj instanceof TryException);
-        }
+  class TryException extends Exception {
+    @Override
+    public boolean equals(Object obj) {
+      return (obj instanceof TryException);
     }
+  }
 }

--- a/core/src/test/java/fj/control/db/TestDbState.java
+++ b/core/src/test/java/fj/control/db/TestDbState.java
@@ -4,7 +4,7 @@ import fj.Unit;
 import fj.data.Option;
 import fj.function.Try1;
 import org.apache.commons.dbutils.DbUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.*;
 
@@ -12,43 +12,44 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestDbState {
-    @Test
-    public void testWriter() throws SQLException {
-        final int TEN = 10;
-        DbState writer = DbState.writer(DbState.driverManager("jdbc:h2:mem:"));
+  @Test
+  void testWriter() throws SQLException {
+    final int TEN = 10;
+    DbState writer = DbState.writer(DbState.driverManager("jdbc:h2:mem:"));
 
-        DB<Unit> setup = DB.db((Try1<Connection, Unit, SQLException>) c -> {
-            Statement s = null;
-            try {
-                s = c.createStatement();
-                assertThat(s.executeUpdate("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))"), is(0));
-                assertThat(s.executeUpdate("INSERT INTO TEST (ID, NAME) VALUES (" + TEN + ", 'FOO')"), is(1));
-            } finally {
-                DbUtils.closeQuietly(s);
-            }
-            return Unit.unit();
-        });
+    DB<Unit> setup = DB.db((Try1<Connection, Unit, SQLException>) c -> {
+      Statement s = null;
+      try {
+        s = c.createStatement();
+        assertThat(s.executeUpdate("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))"), is(0));
+        assertThat(s.executeUpdate("INSERT INTO TEST (ID, NAME) VALUES (" + TEN + ", 'FOO')"), is(1));
+      } finally {
+        DbUtils.closeQuietly(s);
+      }
+      return Unit.unit();
+    });
 
-        DB<Option<Integer>> query = new DB<Option<Integer>>() {
-            @Override
-            public Option<Integer> run(Connection c) throws SQLException {
-                PreparedStatement ps = null;
-                ResultSet rs = null;
-                try {
-                    ps = c.prepareStatement("SELECT ID FROM TEST WHERE NAME = ?");
-                    ps.setString(1, "FOO");
-                    rs = ps.executeQuery();
-                    if (rs.next()) {
-                        return Option.some(rs.getInt("ID"));
-                    } else {
-                        return Option.none();
-                    }
-                } finally {
-                    DbUtils.closeQuietly(rs);
-                    DbUtils.closeQuietly(ps);
-                }
-            }
-        };
-        assertThat(writer.run(setup.bind(v -> query)).some(), is(TEN));
-    }
+    DB<Option<Integer>> query = new DB<Option<Integer>>() {
+      @Override
+      public Option<Integer> run(Connection c) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+          ps = c.prepareStatement("SELECT ID FROM TEST WHERE NAME = ?");
+          ps.setString(1, "FOO");
+          rs = ps.executeQuery();
+          if (rs.next()) {
+            return Option.some(rs.getInt("ID"));
+          }
+          else {
+            return Option.none();
+          }
+        } finally {
+          DbUtils.closeQuietly(rs);
+          DbUtils.closeQuietly(ps);
+        }
+      }
+    };
+    assertThat(writer.run(setup.bind(v -> query)).some(), is(TEN));
+  }
 }

--- a/core/src/test/java/fj/control/parallel/StrategyTest.java
+++ b/core/src/test/java/fj/control/parallel/StrategyTest.java
@@ -8,9 +8,10 @@ import fj.data.Enumerator;
 import fj.data.Java;
 import fj.data.List;
 import fj.data.Stream;
-import org.junit.Test;
 
 import java.util.concurrent.*;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.control.parallel.Callables.callable;
 import static fj.control.parallel.Strategy.*;
@@ -20,50 +21,50 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StrategyTest {
 
-    @Test
-    public void testStrategySeq() {
-        final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
-        assertThat(s.sort(Ord.intOrd, seqStrategy()), is(s.sort(Ord.intOrd)));
-    }
+  @Test
+  void testStrategySeq() {
+    final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
+    assertThat(s.sort(Ord.intOrd, seqStrategy()), is(s.sort(Ord.intOrd)));
+  }
 
-    @Test
-    public void testStrategyThread() {
-        final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
-        assertThat(s.sort(Ord.intOrd, simpleThreadStrategy()), is(s.sort(Ord.intOrd)));
-    }
+  @Test
+  void testStrategyThread() {
+    final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
+    assertThat(s.sort(Ord.intOrd, simpleThreadStrategy()), is(s.sort(Ord.intOrd)));
+  }
 
-    @Test
-    public void testStrategyExecutor() {
-        final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
-        final ExecutorService es = Executors.newFixedThreadPool(10);
-        assertThat(s.sort(Ord.intOrd, executorStrategy(es)), is(s.sort(Ord.intOrd)));
-    }
+  @Test
+  void testStrategyExecutor() {
+    final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
+    final ExecutorService es = Executors.newFixedThreadPool(10);
+    assertThat(s.sort(Ord.intOrd, executorStrategy(es)), is(s.sort(Ord.intOrd)));
+  }
 
-    @Test
-    public void testStrategyCompletion() {
-        final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
-        final ExecutorService es = Executors.newFixedThreadPool(10);
-        final CompletionService<Unit> cs = new ExecutorCompletionService<>(es);
-        assertThat(s.sort(Ord.intOrd, completionStrategy(cs)), is(s.sort(Ord.intOrd)));
-    }
+  @Test
+  void testStrategyCompletion() {
+    final Stream<Integer> s = range(Enumerator.intEnumerator, 99, -99, -1);
+    final ExecutorService es = Executors.newFixedThreadPool(10);
+    final CompletionService<Unit> cs = new ExecutorCompletionService<>(es);
+    assertThat(s.sort(Ord.intOrd, completionStrategy(cs)), is(s.sort(Ord.intOrd)));
+  }
 
-    @Test
-    public void testStrategyMergeAll() {
-        final List<Integer> l = List.range(0, 100);
-        final List<P1<Integer>> p1s = mergeAll(l.map(x -> future(x)));
-        assertThat(P1.sequence(p1s)._1(), is(l));
-    }
+  @Test
+  void testStrategyMergeAll() {
+    final List<Integer> l = List.range(0, 100);
+    final List<P1<Integer>> p1s = mergeAll(l.map(x -> future(x)));
+    assertThat(P1.sequence(p1s)._1(), is(l));
+  }
 
-    public static <A> Future<A> future(A a) {
-        FutureTask<A> ft = new FutureTask<>(() -> a);
-        new Thread(ft).start();
-        return ft;
-    }
+  public static <A> Future<A> future(A a) {
+    FutureTask<A> ft = new FutureTask<>(() -> a);
+    new Thread(ft).start();
+    return ft;
+  }
 
-    @Test
-    public void testStrategyCallables() throws Exception {
-        final Strategy<Callable<Integer>> s = strategy(c -> c);
-        final Strategy<Callable<Integer>> cs = callableStrategy(s);
-        assertThat(callableStrategy(s).par(P.p(callable(1)))._1().call(), is(1));
-    }
+  @Test
+  void testStrategyCallables() throws Exception {
+    final Strategy<Callable<Integer>> s = strategy(c -> c);
+    final Strategy<Callable<Integer>> cs = callableStrategy(s);
+    assertThat(callableStrategy(s).par(P.p(callable(1)))._1().call(), is(1));
+  }
 }

--- a/core/src/test/java/fj/data/ArrayTest.java
+++ b/core/src/test/java/fj/data/ArrayTest.java
@@ -1,7 +1,7 @@
 package fj.data;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -10,11 +10,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ArrayTest {
 
-    @Test
-    public void array_is_safe() {
-        List<Integer> list = List.range(1, 2);
+  @Test
+  void array_is_safe() {
+    List<Integer> list = List.range(1, 2);
 
-        assertThat(list.toArray().array(Integer[].class), instanceOf(Integer[].class));
-    }
+    assertThat(list.toArray().array(Integer[].class), instanceOf(Integer[].class));
+  }
 
 }

--- a/core/src/test/java/fj/data/BooleansTest.java
+++ b/core/src/test/java/fj/data/BooleansTest.java
@@ -2,8 +2,8 @@ package fj.data;
 
 import fj.F;
 import fj.function.Booleans;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static fj.P1.curry;
 import static fj.data.List.list;
@@ -14,66 +14,66 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BooleansTest {
 
-    @Test
-    public void testAnd(){
-        F<String, Boolean> f1 = a -> a.startsWith("fj");
-        F<String, Boolean> f2 = a -> a.contains("data");
+  @Test
+  void testAnd() {
+    F<String, Boolean> f1 = a -> a.startsWith("fj");
+    F<String, Boolean> f2 = a -> a.contains("data");
 
-        F<String, Boolean> f3 = Booleans.and(f1, f2);
+    F<String, Boolean> f3 = Booleans.and(f1, f2);
 
-        Assert.assertTrue(f3.f("fj.data"));
-        Assert.assertTrue(f3.f("fj.data.Function"));
+    Assertions.assertTrue(f3.f("fj.data"));
+    Assertions.assertTrue(f3.f("fj.data.Function"));
 
-    }
+  }
 
-    @Test
-    public void testOr(){
-        F<String, Boolean> f1 = a -> a.startsWith("fj");
-        F<String, Boolean> f2 = a -> a.startsWith("someOtherPackage");
+  @Test
+  void testOr() {
+    F<String, Boolean> f1 = a -> a.startsWith("fj");
+    F<String, Boolean> f2 = a -> a.startsWith("someOtherPackage");
 
-        F<String, Boolean> f3 = Booleans.or(f1, f2);
+    F<String, Boolean> f3 = Booleans.or(f1, f2);
 
-        Assert.assertTrue(f3.f("fj.data"));
-        Assert.assertTrue(f3.f("someOtherPackage.fj.data"));
-        Assert.assertFalse(f3.f("something.fj.data.Function"));
+    Assertions.assertTrue(f3.f("fj.data"));
+    Assertions.assertTrue(f3.f("someOtherPackage.fj.data"));
+    Assertions.assertFalse(f3.f("something.fj.data.Function"));
 
-    }
+  }
 
-    @Test
-    public void testContramap(){
-        F<String, Boolean> f1 = a -> a.length() > 3;
-        F<Integer, String> f2 = a -> a.toString();
+  @Test
+  void testContramap() {
+    F<String, Boolean> f1 = a -> a.length() > 3;
+    F<Integer, String> f2 = a -> a.toString();
 
-        F<Integer, Boolean> f3 = Booleans.contramap(f2, f1);
+    F<Integer, Boolean> f3 = Booleans.contramap(f2, f1);
 
-        Assert.assertTrue(f3.f(1000));
-        Assert.assertFalse(f3.f(100));
+    Assertions.assertTrue(f3.f(1000));
+    Assertions.assertFalse(f3.f(100));
 
-    }
+  }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testAndAll(){
-        F<String, Boolean> f1 = a -> a.endsWith("fj");
-        F<String, Boolean> f2 = a -> a.startsWith("someOtherPackage");
-        F<String, Boolean> f3 = a -> a.length() < 20;
+  @SuppressWarnings("unchecked")
+  @Test
+  void testAndAll() {
+    F<String, Boolean> f1 = a -> a.endsWith("fj");
+    F<String, Boolean> f2 = a -> a.startsWith("someOtherPackage");
+    F<String, Boolean> f3 = a -> a.length() < 20;
 
-        F<String, Boolean> f4 = Booleans.andAll(Stream.<F<String, Boolean>>stream(f1, f2, f3));
+    F<String, Boolean> f4 = Booleans.andAll(Stream.<F<String, Boolean>>stream(f1, f2, f3));
 
-        Assert.assertTrue(f4.f("someOtherPackage.fj"));
-        Assert.assertFalse(f4.f("otther"));
-        Assert.assertFalse(f4.f("someOtherPackage.fj.data.something.really.big"));
+    Assertions.assertTrue(f4.f("someOtherPackage.fj"));
+    Assertions.assertFalse(f4.f("otther"));
+    Assertions.assertFalse(f4.f("someOtherPackage.fj.data.something.really.big"));
 
-    }
+  }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testIsNot(){
-        F<Integer, Boolean> f1 = a -> a == 4;
-        List<String> result = list("some", "come", "done!").filter(isnot(String::length, f1));
+  @SuppressWarnings("unchecked")
+  @Test
+  void testIsNot() {
+    F<Integer, Boolean> f1 = a -> a == 4;
+    List<String> result = list("some", "come", "done!").filter(isnot(String::length, f1));
 
-        assertThat(result.length(), is(1));
-        Assert.assertEquals(result, list("done!"));
+    assertThat(result.length(), is(1));
+    Assertions.assertEquals(result, list("done!"));
 
-    }
+  }
 }

--- a/core/src/test/java/fj/data/DListTest.java
+++ b/core/src/test/java/fj/data/DListTest.java
@@ -1,6 +1,6 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.data.DList.*;
 import static org.hamcrest.core.Is.is;
@@ -8,25 +8,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class DListTest {
-    @Test
-    public void testConsSnoc() {
-        assertThat(nil().snoc(2).cons(1).toJavaList(), is(single(1).snoc(2).toJavaList()));
-    }
+  @Test
+  void testConsSnoc() {
+    assertThat(nil().snoc(2).cons(1).toJavaList(), is(single(1).snoc(2).toJavaList()));
+  }
 
-    @Test
-    public void testListDList() {
-        DList<Integer> d = listDList(List.range(0, 1000));
-        assertThat(d.toJavaList(), is(List.range(0, 1000).toJavaList()));
-    }
+  @Test
+  void testListDList() {
+    DList<Integer> d = listDList(List.range(0, 1000));
+    assertThat(d.toJavaList(), is(List.range(0, 1000).toJavaList()));
+  }
 
-    @Test
-    public void testArrayDList() {
-        DList<Integer> d = arrayDList(Array.range(0, 1000).array(Integer[].class));
-        assertThat(d.toJavaList(), is(Array.range(0, 1000).toJavaList()));
-    }
-    @Test
-    public void testIter() {
-        DList<Integer> d = iteratorDList(List.range(0, 1000).iterator());
-        assertThat(d.toJavaList(), is(List.range(0, 1000).toJavaList()));
-    }
+  @Test
+  void testArrayDList() {
+    DList<Integer> d = arrayDList(Array.range(0, 1000).array(Integer[].class));
+    assertThat(d.toJavaList(), is(Array.range(0, 1000).toJavaList()));
+  }
+
+  @Test
+  void testIter() {
+    DList<Integer> d = iteratorDList(List.range(0, 1000).iterator());
+    assertThat(d.toJavaList(), is(List.range(0, 1000).toJavaList()));
+  }
 }

--- a/core/src/test/java/fj/data/EitherTest.java
+++ b/core/src/test/java/fj/data/EitherTest.java
@@ -1,6 +1,7 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -8,25 +9,26 @@ import static fj.Function.constant;
 import static fj.P.p;
 import static fj.Unit.unit;
 import static fj.data.Either.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class EitherTest {
 
-  public static final class LeftProjectionTest {
+  @Nested
+  public final class LeftProjectionTest {
     @Test
-    public void testIterator() {
+    void testIterator() {
       assertEquals(0L, (long) left(0L).left().iterator().next());
       assertFalse(right(0).left().iterator().hasNext());
     }
 
     @Test
-    public void testEither() {
+    void testEither() {
       assertEquals(left(0), left(0).left().either());
       assertEquals(right(0), right(0).left().either());
     }
 
     @Test
-    public void testValueEString() {
+    void testValueEString() {
       assertEquals(0L, (long) left(0L).left().valueE("zero"));
 
       try {
@@ -38,7 +40,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testValueEF0() {
+    void testValueEF0() {
       assertEquals(0L, (long) left(0L).left().valueE(() -> "zero"));
 
       try {
@@ -50,7 +52,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testValue() {
+    void testValue() {
       assertEquals(0L, (long) left(0L).left().value());
 
       try {
@@ -62,25 +64,25 @@ public final class EitherTest {
     }
 
     @Test
-    public void testOrValue() {
+    void testOrValue() {
       assertEquals(0L, (long) left(0L).left().orValue(1L));
       assertEquals(1L, (long) right(0L).left().orValue(1L));
     }
 
     @Test
-    public void testOrValueF0() {
+    void testOrValueF0() {
       assertEquals(0L, (long) left(0L).left().orValue(() -> 1L));
       assertEquals(1L, (long) right(0L).left().orValue(() -> 1L));
     }
 
     @Test
-    public void testOn() {
+    void testOn() {
       assertEquals(0L, (long) Either.<Long, Long>left(0L).left().on(constant(1L)));
       assertEquals(1L, (long) Either.<Long, Long>right(0L).left().on(constant(1L)));
     }
 
     @Test
-    public void testForeach() {
+    void testForeach() {
       left(0).left().foreach(constant(unit()));
       right(0).left().foreach(ignore -> {
         fail();
@@ -89,26 +91,26 @@ public final class EitherTest {
     }
 
     @Test
-    public void testForeachDoEffect() {
+    void testForeachDoEffect() {
       left(0).left().foreachDoEffect(ignore -> {
       });
       right(0).left().foreachDoEffect(ignore -> fail());
     }
 
     @Test
-    public void testMap() {
+    void testMap() {
       assertEquals(left(0), left("zero").left().map(constant(0)));
       assertEquals(right("zero"), right("zero").left().map(constant(0)));
     }
 
     @Test
-    public void testBind() {
+    void testBind() {
       assertEquals(left(0), left("zero").left().bind(constant(left(0))));
       assertEquals(right("zero"), right("zero").left().bind(constant(left(0))));
     }
 
     @Test
-    public void testSequence() {
+    void testSequence() {
       assertEquals(left(0), left("zero").left().sequence(left(0)));
       assertEquals(right(0), left("zero").left().sequence(right(0)));
       assertEquals(right("zero"), right("zero").left().sequence(left(0)));
@@ -116,7 +118,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseList() {
+    void testTraverseList() {
       assertEquals(List.nil(), left("zero").left().traverseList(constant(List.nil())));
       assertEquals(List.single(left(0)), left("zero").left().traverseList(constant(List.single(0))));
       assertEquals(List.arrayList(left(0), left(1)), left("zero").left().traverseList(constant(List.arrayList(0, 1))));
@@ -126,19 +128,19 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseIO() throws IOException {
+    void testTraverseIO() throws IOException {
       assertEquals(left(0), left("zero").left().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
       assertEquals(right("zero"), right("zero").left().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     }
 
     @Test
-    public void testTraverseP1() {
+    void testTraverseP1() {
       assertEquals(p(left(0)), left("zero").left().traverseP1(constant(p(0))));
       assertEquals(p(right("zero")), right("zero").left().traverseP1(constant(p(0))));
     }
 
     @Test
-    public void testFilter() {
+    void testFilter() {
       assertEquals(Option.none(), left(0).left().filter(constant(false)));
       assertEquals(Option.none(), right(0).left().filter(constant(false)));
       assertEquals(Option.some(left(0)), left(0).left().filter(constant(true)));
@@ -146,13 +148,13 @@ public final class EitherTest {
     }
 
     @Test
-    public void testApply() {
+    void testApply() {
       assertEquals(left(1), left("zero").left().apply(left(constant(1))));
       assertEquals(right("zero"), right("zero").left().apply(left(constant(1))));
     }
 
     @Test
-    public void testForAll() {
+    void testForAll() {
       assertFalse(left(0).left().forall(constant(false)));
       assertTrue(right(0).left().forall(constant(false)));
       assertTrue(left(0).left().forall(constant(true)));
@@ -160,7 +162,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testExists() {
+    void testExists() {
       assertFalse(left(0).left().exists(constant(false)));
       assertFalse(right(0).left().exists(constant(false)));
       assertTrue(left(0).left().exists(constant(true)));
@@ -168,38 +170,38 @@ public final class EitherTest {
     }
 
     @Test
-    public void testToList() {
+    void testToList() {
       assertEquals(List.single(0), left(0).left().toList());
       assertEquals(List.nil(), right(0).left().toList());
     }
 
     @Test
-    public void testToOption() {
+    void testToOption() {
       assertEquals(Option.some(0), left(0).left().toOption());
       assertEquals(Option.none(), right(0).left().toOption());
     }
 
     @Test
-    public void testToArray() {
+    void testToArray() {
       assertEquals(Array.single(0), left(0).left().toArray());
       assertEquals(Array.empty(), right(0).left().toArray());
     }
 
     @Test
-    public void testToStream() {
+    void testToStream() {
       assertEquals(Stream.single(0), left(0).left().toStream());
       assertEquals(Stream.nil(), right(0).left().toStream());
     }
 
     @Test
-    public void testToCollection() {
+    void testToCollection() {
       assertEquals(1L, left(0L).left().toCollection().size());
       assertEquals(0L, (long) left(0L).left().toCollection().iterator().next());
       assertTrue(right(0).left().toCollection().isEmpty());
     }
 
     @Test
-    public void testTraverseOption() {
+    void testTraverseOption() {
       assertEquals(Option.none(), left("zero").left().traverseOption(constant(Option.none())));
       assertEquals(Option.some(left(0)), left("zero").left().traverseOption(constant(Option.some(0))));
       assertEquals(Option.some(right("zero")), right("zero").left().traverseOption(constant(Option.none())));
@@ -207,7 +209,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseStream() {
+    void testTraverseStream() {
       assertEquals(Stream.nil(), left("zero").left().traverseStream(constant(Stream.nil())));
       assertEquals(Stream.single(left(0)), left("zero").left().traverseStream(constant(Stream.single(0))));
       assertEquals(Stream.arrayStream(left(0), left(1)), left("zero").left().traverseStream(constant(Stream.arrayStream(0, 1))));
@@ -217,21 +219,22 @@ public final class EitherTest {
     }
   }
 
-  public static final class RightProjectionTest {
+  @Nested
+  public final class RightProjectionTest {
     @Test
-    public void testIterator() {
+    void testIterator() {
       assertEquals(0L, (long) right(0L).right().iterator().next());
       assertFalse(left(0).right().iterator().hasNext());
     }
 
     @Test
-    public void testEither() {
+    void testEither() {
       assertEquals(right(0), right(0).right().either());
       assertEquals(left(0), left(0).right().either());
     }
 
     @Test
-    public void testValueEString() {
+    void testValueEString() {
       assertEquals(0L, (long) right(0L).right().valueE("zero"));
 
       try {
@@ -243,7 +246,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testValueEF0() {
+    void testValueEF0() {
       assertEquals(0L, (long) right(0L).right().valueE(() -> "zero"));
 
       try {
@@ -255,7 +258,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testValue() {
+    void testValue() {
       assertEquals(0L, (long) right(0L).right().value());
 
       try {
@@ -267,25 +270,25 @@ public final class EitherTest {
     }
 
     @Test
-    public void testOrValue() {
+    void testOrValue() {
       assertEquals(0L, (long) right(0L).right().orValue(1L));
       assertEquals(1L, (long) left(0L).right().orValue(1L));
     }
 
     @Test
-    public void testOrValueF0() {
+    void testOrValueF0() {
       assertEquals(0L, (long) right(0L).right().orValue(() -> 1L));
       assertEquals(1L, (long) left(0L).right().orValue(() -> 1L));
     }
 
     @Test
-    public void testOn() {
+    void testOn() {
       assertEquals(0L, (long) Either.<Long, Long>right(0L).right().on(constant(1L)));
       assertEquals(1L, (long) Either.<Long, Long>left(0L).right().on(constant(1L)));
     }
 
     @Test
-    public void testForeach() {
+    void testForeach() {
       right(0).right().foreach(constant(unit()));
       left(0).right().foreach(ignore -> {
         fail();
@@ -294,26 +297,26 @@ public final class EitherTest {
     }
 
     @Test
-    public void testForeachDoEffect() {
+    void testForeachDoEffect() {
       right(0).right().foreachDoEffect(ignore -> {
       });
       left(0).right().foreachDoEffect(ignore -> fail());
     }
 
     @Test
-    public void testMap() {
+    void testMap() {
       assertEquals(right(0), right("zero").right().map(constant(0)));
       assertEquals(left("zero"), left("zero").right().map(constant(0)));
     }
 
     @Test
-    public void testBind() {
+    void testBind() {
       assertEquals(right(0), right("zero").right().bind(constant(right(0))));
       assertEquals(left("zero"), left("zero").right().bind(constant(right(0))));
     }
 
     @Test
-    public void testSequence() {
+    void testSequence() {
       assertEquals(right(0), right("zero").right().sequence(right(0)));
       assertEquals(left(0), right("zero").right().sequence(left(0)));
       assertEquals(left("zero"), left("zero").right().sequence(right(0)));
@@ -321,7 +324,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseList() {
+    void testTraverseList() {
       assertEquals(List.nil(), right("zero").right().traverseList(constant(List.nil())));
       assertEquals(List.single(right(0)), right("zero").right().traverseList(constant(List.single(0))));
       assertEquals(List.arrayList(right(0), right(1)), right("zero").right().traverseList(constant(List.arrayList(0, 1))));
@@ -331,19 +334,19 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseIO() throws IOException {
+    void testTraverseIO() throws IOException {
       assertEquals(right(0), right("zero").right().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
       assertEquals(left("zero"), left("zero").right().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     }
 
     @Test
-    public void testTraverseP1() {
+    void testTraverseP1() {
       assertEquals(p(right(0)), right("zero").right().traverseP1(constant(p(0))));
       assertEquals(p(left("zero")), left("zero").right().traverseP1(constant(p(0))));
     }
 
     @Test
-    public void testFilter() {
+    void testFilter() {
       assertEquals(Option.none(), right(0).right().filter(constant(false)));
       assertEquals(Option.none(), left(0).right().filter(constant(false)));
       assertEquals(Option.some(right(0)), right(0).right().filter(constant(true)));
@@ -351,13 +354,13 @@ public final class EitherTest {
     }
 
     @Test
-    public void testApply() {
+    void testApply() {
       assertEquals(right(1), right("zero").right().apply(right(constant(1))));
       assertEquals(left("zero"), left("zero").right().apply(right(constant(1))));
     }
 
     @Test
-    public void testForAll() {
+    void testForAll() {
       assertFalse(right(0).right().forall(constant(false)));
       assertTrue(left(0).right().forall(constant(false)));
       assertTrue(right(0).right().forall(constant(true)));
@@ -365,7 +368,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testExists() {
+    void testExists() {
       assertFalse(right(0).right().exists(constant(false)));
       assertFalse(left(0).right().exists(constant(false)));
       assertTrue(right(0).right().exists(constant(true)));
@@ -373,38 +376,38 @@ public final class EitherTest {
     }
 
     @Test
-    public void testToList() {
+    void testToList() {
       assertEquals(List.single(0), right(0).right().toList());
       assertEquals(List.nil(), left(0).right().toList());
     }
 
     @Test
-    public void testToOption() {
+    void testToOption() {
       assertEquals(Option.some(0), right(0).right().toOption());
       assertEquals(Option.none(), left(0).right().toOption());
     }
 
     @Test
-    public void testToArray() {
+    void testToArray() {
       assertEquals(Array.single(0), right(0).right().toArray());
       assertEquals(Array.empty(), left(0).right().toArray());
     }
 
     @Test
-    public void testToStream() {
+    void testToStream() {
       assertEquals(Stream.single(0), right(0).right().toStream());
       assertEquals(Stream.nil(), left(0).right().toStream());
     }
 
     @Test
-    public void testToCollection() {
+    void testToCollection() {
       assertEquals(1L, right(0L).right().toCollection().size());
       assertEquals(0L, (long) right(0L).right().toCollection().iterator().next());
       assertTrue(left(0).right().toCollection().isEmpty());
     }
 
     @Test
-    public void testTraverseOption() {
+    void testTraverseOption() {
       assertEquals(Option.none(), right("zero").right().traverseOption(constant(Option.none())));
       assertEquals(Option.some(right(0)), right("zero").right().traverseOption(constant(Option.some(0))));
       assertEquals(Option.some(left("zero")), left("zero").right().traverseOption(constant(Option.none())));
@@ -412,7 +415,7 @@ public final class EitherTest {
     }
 
     @Test
-    public void testTraverseStream() {
+    void testTraverseStream() {
       assertEquals(Stream.nil(), right("zero").right().traverseStream(constant(Stream.nil())));
       assertEquals(Stream.single(right(0)), right("zero").right().traverseStream(constant(Stream.single(0))));
       assertEquals(Stream.arrayStream(right(0), right(1)), right("zero").right().traverseStream(constant(Stream.arrayStream(0, 1))));
@@ -423,31 +426,31 @@ public final class EitherTest {
   }
 
   @Test
-  public void testIsLeft() {
+  void testIsLeft() {
     assertTrue(left(0).isLeft());
     assertFalse(right(0).isLeft());
   }
 
   @Test
-  public void testIsRight() {
+  void testIsRight() {
     assertFalse(left(0).isRight());
     assertTrue(right(0).isRight());
   }
 
   @Test
-  public void testEither() {
+  void testEither() {
     assertEquals(-1L, (long) left("zero").either(constant(-1L), constant(1L)));
     assertEquals(1L, (long) right("zero").either(constant(-1L), constant(1L)));
   }
 
   @Test
-  public void testBimap() {
+  void testBimap() {
     assertEquals(left(-1), left("zero").bimap(constant(-1), constant(1)));
     assertEquals(right(1), right("zero").bimap(constant(-1), constant(1)));
   }
 
   @Test
-  public void testTestEquals() {
+  void testTestEquals() {
     assertNotEquals(null, left(0));
     assertNotEquals(new Object(), left(0));
     assertNotEquals(left(0), right(0));
@@ -460,7 +463,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTestHashCode() {
+  void testTestHashCode() {
     assertEquals(left(0).hashCode(), left(0).hashCode());
     assertEquals(left(0).hashCode(), right(0).hashCode());
     assertEquals(right(0).hashCode(), left(0).hashCode());
@@ -468,53 +471,53 @@ public final class EitherTest {
   }
 
   @Test
-  public void testSwap() {
+  void testSwap() {
     assertEquals(right(0), left(0).swap());
     assertEquals(left(0), right(0).swap());
   }
 
   @Test
-  public void testLeft_() {
+  void testLeft_() {
     assertEquals(left(0), left_().f(0));
   }
 
   @Test
-  public void testRight_() {
+  void testRight_() {
     assertEquals(right(0), right_().f(0));
   }
 
   @Test
-  public void testEither_() {
+  void testEither_() {
     assertEquals(-1L, (long) either_(constant(-1L), constant(1L)).f(left("zero")));
     assertEquals(1L, (long) either_(constant(-1L), constant(1L)).f(right("zero")));
   }
 
   @Test
-  public void testLeftMap() {
+  void testLeftMap() {
     assertEquals(left(0), left("zero").leftMap(constant(0)));
     assertEquals(right("zero"), right("zero").leftMap(constant(0)));
   }
 
   @Test
-  public void testLeftMap_() {
+  void testLeftMap_() {
     assertEquals(left(0), leftMap_().f(constant(0)).f(left("zero")));
     assertEquals(right("zero"), leftMap_().f(constant(0)).f(right("zero")));
   }
 
   @Test
-  public void testRightMap() {
+  void testRightMap() {
     assertEquals(left("zero"), left("zero").rightMap(constant(0)));
     assertEquals(right(0), right("zero").rightMap(constant(0)));
   }
 
   @Test
-  public void testRightMap_() {
+  void testRightMap_() {
     assertEquals(left("zero"), rightMap_().f(constant(0)).f(left("zero")));
     assertEquals(right(0), rightMap_().f(constant(0)).f(right("zero")));
   }
 
   @Test
-  public void testJoinLeft() {
+  void testJoinLeft() {
     assertEquals(left(0), joinLeft(left(left(0))));
     assertEquals(right(0), joinLeft(left(right(0))));
     assertEquals(right(left(0)), joinLeft(right(left(0))));
@@ -522,7 +525,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testJoinRight() {
+  void testJoinRight() {
     assertEquals(left(left(0)), joinRight(left(left(0))));
     assertEquals(left(right(0)), joinRight(left(right(0))));
     assertEquals(left(0), joinRight(right(left(0))));
@@ -530,21 +533,21 @@ public final class EitherTest {
   }
 
   @Test
-  public void testSequenceLeft() {
+  void testSequenceLeft() {
     assertEquals(left(List.nil()), sequenceLeft(List.nil()));
     assertEquals(left(List.single("zero")), sequenceLeft(List.single(left("zero"))));
     assertEquals(right("zero"), sequenceLeft(List.single(right("zero"))));
   }
 
   @Test
-  public void testSequenceRight() {
+  void testSequenceRight() {
     assertEquals(right(List.nil()), sequenceRight(List.nil()));
     assertEquals(right(List.single("zero")), sequenceRight(List.single(right("zero"))));
     assertEquals(left("zero"), sequenceRight(List.single(left("zero"))));
   }
 
   @Test
-  public void testTraverseListRight() {
+  void testTraverseListRight() {
     assertEquals(List.single(left("zero")), left("zero").traverseListRight(constant(List.nil())));
     assertEquals(List.single(left("zero")), left("zero").traverseListRight(constant(List.single(0))));
     assertEquals(List.single(left("zero")), left("zero").traverseListRight(constant(List.arrayList(0, 1))));
@@ -554,7 +557,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTraverseListLeft() {
+  void testTraverseListLeft() {
     assertEquals(List.nil(), left("zero").traverseListLeft(constant(List.nil())));
     assertEquals(List.single(left(0)), left("zero").traverseListLeft(constant(List.single(0))));
     assertEquals(List.arrayList(left(0), left(1)), left("zero").traverseListLeft(constant(List.arrayList(0, 1))));
@@ -564,19 +567,19 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTraverseIORight() throws IOException {
+  void testTraverseIORight() throws IOException {
     assertEquals(left("zero"), left("zero").traverseIORight(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(right(0), right("zero").traverseIORight(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseIOLeft() throws IOException {
+  void testTraverseIOLeft() throws IOException {
     assertEquals(left(0), left("zero").traverseIOLeft(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(right("zero"), right("zero").traverseIOLeft(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseOptionRight() {
+  void testTraverseOptionRight() {
     assertEquals(Option.some(left("zero")), left("zero").traverseOptionRight(constant(Option.none())));
     assertEquals(Option.some(left("zero")), left("zero").traverseOptionRight(constant(Option.some(0))));
     assertEquals(Option.none(), right("zero").traverseOptionRight(constant(Option.none())));
@@ -584,7 +587,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTraverseOptionLeft() {
+  void testTraverseOptionLeft() {
     assertEquals(Option.none(), left("zero").traverseOptionLeft(constant(Option.none())));
     assertEquals(Option.some(left(0)), left("zero").traverseOptionLeft(constant(Option.some(0))));
     assertEquals(Option.some(right("zero")), right("zero").traverseOptionLeft(constant(Option.none())));
@@ -592,7 +595,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTraverseStreamRight() {
+  void testTraverseStreamRight() {
     assertEquals(Stream.single(left("zero")), left("zero").traverseStreamRight(constant(Stream.nil())));
     assertEquals(Stream.single(left("zero")), left("zero").traverseStreamRight(constant(Stream.single(0))));
     assertEquals(Stream.single(left("zero")), left("zero").traverseStreamRight(constant(Stream.arrayStream(0, 1))));
@@ -602,7 +605,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTraverseStreamLeft() {
+  void testTraverseStreamLeft() {
     assertEquals(Stream.nil(), left("zero").traverseStreamLeft(constant(Stream.nil())));
     assertEquals(Stream.single(left(0)), left("zero").traverseStreamLeft(constant(Stream.single(0))));
     assertEquals(Stream.arrayStream(left(0), left(1)), left("zero").traverseStreamLeft(constant(Stream.arrayStream(0, 1))));
@@ -612,19 +615,19 @@ public final class EitherTest {
   }
 
   @Test
-  public void testReduce() {
+  void testReduce() {
     assertEquals(0L, (long) reduce(left(0L)));
     assertEquals(0L, (long) reduce(right(0L)));
   }
 
   @Test
-  public void testIif() {
+  void testIif() {
     assertEquals(right(-1), iif(true, () -> -1, () -> 1));
     assertEquals(left(1), iif(false, () -> -1, () -> 1));
   }
 
   @Test
-  public void testLefts() {
+  void testLefts() {
     assertEquals(List.nil(), lefts(List.nil()));
     assertEquals(List.single(0), lefts(List.single(left(0))));
     assertEquals(List.nil(), lefts(List.single(right(0))));
@@ -635,7 +638,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testRights() {
+  void testRights() {
     assertEquals(List.nil(), rights(List.nil()));
     assertEquals(List.single(0), rights(List.single(right(0))));
     assertEquals(List.single(0), lefts(List.single(left(0))));
@@ -646,7 +649,7 @@ public final class EitherTest {
   }
 
   @Test
-  public void testTestToString() {
+  void testTestToString() {
     assertNotNull(left(0).toString());
     assertNotNull(right(0).toString());
   }

--- a/core/src/test/java/fj/data/EvalTest.java
+++ b/core/src/test/java/fj/data/EvalTest.java
@@ -2,58 +2,58 @@ package fj.data;
 
 import fj.F0;
 import fj.F2;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
 public class EvalTest {
 
   @Test
-  public void testNow() {
+  void testNow() {
     Eval<Integer> eval = Eval.now(1);
-    Assert.assertEquals(eval.value().intValue(), 1);
-    Assert.assertEquals(eval.map(a -> a.toString()).value(), "1");
-    Assert.assertEquals(eval.bind(a -> Eval.now(a * 3)).value().intValue(), 3);
+    Assertions.assertEquals(eval.value().intValue(), 1);
+    Assertions.assertEquals(eval.map(a -> a.toString()).value(), "1");
+    Assertions.assertEquals(eval.bind(a -> Eval.now(a * 3)).value().intValue(), 3);
   }
 
   @Test
-  public void testLater() {
+  void testLater() {
     InvocationTrackingF<Integer> tracker = new InvocationTrackingF<>(1);
     Eval<Integer> eval = Eval.later(tracker);
 
-    Assert.assertEquals(tracker.getInvocationCounter(), 0);
-    Assert.assertEquals(eval.value().intValue(), 1);
-    Assert.assertEquals(tracker.getInvocationCounter(), 1);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 0);
+    Assertions.assertEquals(eval.value().intValue(), 1);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 1);
     eval.value();
-    Assert.assertEquals(tracker.getInvocationCounter(), 1);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 1);
   }
 
   @Test
-  public void testAlways() {
+  void testAlways() {
     InvocationTrackingF<Integer> tracker = new InvocationTrackingF<>(1);
     Eval<Integer> eval = Eval.always(tracker);
 
-    Assert.assertEquals(tracker.getInvocationCounter(), 0);
-    Assert.assertEquals(eval.value().intValue(), 1);
-    Assert.assertEquals(tracker.getInvocationCounter(), 1);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 0);
+    Assertions.assertEquals(eval.value().intValue(), 1);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 1);
     eval.value();
     eval.value();
-    Assert.assertEquals(tracker.getInvocationCounter(), 3);
+    Assertions.assertEquals(tracker.getInvocationCounter(), 3);
   }
 
   @Test
-  public void testDefer() {
+  void testDefer() {
     // Make sure that a recursive computation is actually stack-safe.
     int targetValue = 200000;
     Iterator<Integer> it = Enumerator.intEnumerator.toStream(0).iterator();
     Eval<Boolean> result = foldRight(it, (v, acc) -> v == targetValue ? Eval.now(true) : acc, false);
-    Assert.assertTrue(result.value());
+    Assertions.assertTrue(result.value());
   }
 
   private static <A, T> Eval<A> foldRight(Iterator<T> iterator,
-                                          F2<T, Eval<A>, Eval<A>> f,
-                                          A zero) {
+      F2<T, Eval<A>, Eval<A>> f,
+      A zero) {
     if (!iterator.hasNext()) {
       return Eval.now(zero);
     }

--- a/core/src/test/java/fj/data/IOFunctionsTest.java
+++ b/core/src/test/java/fj/data/IOFunctionsTest.java
@@ -1,10 +1,10 @@
 package fj.data;
 
 import fj.*;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.*;
+
+import org.junit.jupiter.api.Test;
 import java.io.Reader;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -13,12 +13,12 @@ import static fj.data.Stream.cons;
 import static fj.data.Stream.nil_;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class IOFunctionsTest {
 
   @Test
-  public void bracket_happy_path() throws Exception {
+  void bracket_happy_path() throws Exception {
     AtomicBoolean closed = new AtomicBoolean();
     Reader reader = new StringReader("Read OK") {
       @Override
@@ -39,7 +39,7 @@ public class IOFunctionsTest {
   }
 
   @Test
-  public void bracket_exception_path() throws Exception {
+  void bracket_exception_path() throws Exception {
     AtomicBoolean closed = new AtomicBoolean();
     Reader reader = new StringReader("Read OK") {
       @Override
@@ -53,7 +53,9 @@ public class IOFunctionsTest {
     IO<String> bracketed = IOFunctions.bracket(
         () -> reader,
         IOFunctions.closeReader,
-        r -> () -> {throw new IllegalArgumentException("OoO");}
+        r -> () -> {
+          throw new IllegalArgumentException("OoO");
+        }
     );
 
     try {
@@ -66,7 +68,7 @@ public class IOFunctionsTest {
   }
 
   @Test
-  public void testTraverseIO() throws IOException {
+  void testTraverseIO() throws IOException {
     String[] as = {"foo1", "bar2", "foobar3"};
     Stream<String> stream = Stream.arrayStream(as);
     ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -78,7 +80,7 @@ public class IOFunctionsTest {
   }
 
   @Test
-  public void testSequenceWhile() throws IOException {
+  void testSequenceWhile() throws IOException {
     BufferedReader r = new BufferedReader(new StringReader("foo1\nbar2\nfoobar3"));
     Stream<IO<String>> s1 = Stream.repeat(() -> r.readLine());
     IO<Stream<String>> io = sequenceWhile(s1, s -> !s.equals("foobar3"));
@@ -86,7 +88,7 @@ public class IOFunctionsTest {
   }
 
   @Test
-  public void testForeach() throws IOException {
+  void testForeach() throws IOException {
     Stream<IO<String>> s1 = Stream.repeat(() -> "foo1");
     IO<Stream<String>> io = sequence(s1.take(2));
     ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -99,14 +101,14 @@ public class IOFunctionsTest {
 
 
   @Test
-  public void testReplicateM() throws IOException {
+  void testReplicateM() throws IOException {
     final IO<String> is = () -> new BufferedReader(new StringReader("foo")).readLine();
     assertThat(replicateM(is, 3).run(), is(List.list("foo", "foo", "foo")));
   }
 
 
   @Test
-  public void testLift() throws IOException {
+  void testLift() throws IOException {
     final IO<String> readName = () -> new BufferedReader(new StringReader("foo")).readLine();
     F<String, IO<String>> f = this::println;
     final F<String, IO<String>> upperCaseAndPrint = f.<String>o().f(String::toUpperCase);

--- a/core/src/test/java/fj/data/JavaTest.java
+++ b/core/src/test/java/fj/data/JavaTest.java
@@ -1,9 +1,10 @@
 package fj.data;
 
 import fj.Show;
-import org.junit.Test;
 
 import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Show.listShow;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,15 +12,16 @@ import static org.hamcrest.core.Is.is;
 
 public class JavaTest {
 
-	@Test
-	public void test1() {
-		// #33: Fixes ClassCastException
-		final List<Colors> colors = Java.<Colors>EnumSet_List().f(EnumSet.allOf(Colors.class));
-		assertThat(listShow(Show.<Colors>anyShow()).showS(colors), is("List(red,green,blue)"));
-	}
+  @Test
+  void test1() {
+    // #33: Fixes ClassCastException
+    final List<Colors> colors = Java.<Colors>EnumSet_List().f(EnumSet.allOf(Colors.class));
+    assertThat(listShow(Show.<Colors>anyShow()).showS(colors), is("List(red,green,blue)"));
+  }
 
-	enum Colors {
-		red, green, blue
-	}
+  enum Colors {
+    
+    red, green, blue
+  }
 
 }

--- a/core/src/test/java/fj/data/LazyStringTest.java
+++ b/core/src/test/java/fj/data/LazyStringTest.java
@@ -1,6 +1,6 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -9,11 +9,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LazyStringTest {
 
-    @Test
-    public void testToString() {
-        Stream<LazyString> s = Stream.repeat(LazyString.str("abc"));
-        // FJ 4.3 blows the stack when printing infinite streams of lazy strings.
-        assertThat(s.toString(), is(equalTo("Cons(LazyString(a, ?), ?)")));
-    }
+  @Test
+  void testToString() {
+    Stream<LazyString> s = Stream.repeat(LazyString.str("abc"));
+    // FJ 4.3 blows the stack when printing infinite streams of lazy strings.
+    assertThat(s.toString(), is(equalTo("Cons(LazyString(a, ?), ?)")));
+  }
 
 }

--- a/core/src/test/java/fj/data/ListBufferTest.java
+++ b/core/src/test/java/fj/data/ListBufferTest.java
@@ -1,6 +1,6 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -8,15 +8,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ListBufferTest {
 
-	@Test
-	public void testSnoc() {
-		// test case for #181
-		List.Buffer<Integer> buf = List.Buffer.empty();
-		buf.snoc(1).snoc(2).snoc(3);
-		List<Integer> list1 = buf.toList();
-		buf.snoc(4);
-		List<Integer> list2 = buf.toList();
-		assertThat(list2, equalTo(Stream.range(1, 5).toList()));
-	}
+  @Test
+  void testSnoc() {
+    // test case for #181
+    List.Buffer<Integer> buf = List.Buffer.empty();
+    buf.snoc(1).snoc(2).snoc(3);
+    List<Integer> list1 = buf.toList();
+    buf.snoc(4);
+    List<Integer> list2 = buf.toList();
+    assertThat(list2, equalTo(Stream.range(1, 5).toList()));
+  }
 
 }

--- a/core/src/test/java/fj/data/ListTest.java
+++ b/core/src/test/java/fj/data/ListTest.java
@@ -2,9 +2,10 @@ package fj.data;
 
 import fj.*;
 import fj.control.Trampoline;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static fj.Function.constant;
@@ -30,122 +31,122 @@ import static fj.data.Option.*;
 import static fj.data.Validation.fail;
 import static fj.data.Validation.*;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class ListTest {
 
-    @Test
-    public void objectMethods() {
+  @Test
+  void objectMethods() {
 
-        int max = 5;
-        List<Integer> list = List.range(1, max);
+    int max = 5;
+    List<Integer> list = List.range(1, max);
 
-        assertTrue(list.equals(list));
-        assertTrue(list.equals(List.range(1, max)));
+    assertTrue(list.equals(list));
+    assertTrue(list.equals(List.range(1, max)));
 
-        assertFalse(list.equals(List.single(1)));
-        assertFalse(list.equals(true));
-        assertFalse(list.equals(null));
+    assertFalse(list.equals(List.single(1)));
+    assertFalse(list.equals(true));
+    assertFalse(list.equals(null));
 
 
+    assertTrue(List.list(1, 2).toString().equals("List(1,2)"));
 
-        assertTrue(List.list(1, 2).toString().equals("List(1,2)"));
-
-    }
-
-    @Test
-    public void integration() {
-        java.util.List<Integer> ul = Arrays.asList(1, 2, 3);
-        List<Integer> dl = List.iterableList(ul);
-        assertTrue(ul.equals(dl.toJavaList()));
-
-    }
-
-    @Test
-    public void convertToString() {
-        final int n = 10000;
-        final StringBuilder expected = new StringBuilder("List(");
-        for (int i = 0; i < n; i++) {
-            expected.append(i);
-            if (i < n - 1) {
-                expected.append(',');
-            }
-        }
-        expected.append(')');
-        assertEquals(expected.toString(), List.range(0, n).toString());
-    }
-
-    @Test
-    public void partition() {
-        P2<List<Integer>, List<Integer>> p = List.range(1, 5).partition(i -> i % 2 == 0);
-        Equal<List<Integer>> e = Equal.listEqual(Equal.intEqual);
-        assertTrue(e.eq(p._1(), List.list(2, 4)));
-        assertTrue(e.eq(p._2(), List.list(1, 3)));
-    }
-
-    @Test
-    public void intersperseOverflow() {
-        // should not overflow
-        int n = 100000;
-        List<Integer> list = List.replicate(n, 1).intersperse(2);
-        String s = list.toString();
-    }
-
-    @Test
-    public void listReduce() {
-        String list = List.range(1, 11).uncons((a, la) -> List.cons(a, la).toString(), "");
-        String expected = List.range(1, 11).toString();
-        assertThat(expected, equalTo(list));
-    }
-
-    @Test
-    public void array() {
-        final int max = 3;
-        Integer[] ints = new Integer[max];
-        for (int i = 0; i < max; i++) {
-            ints[i] = i + 1;
-        };
-        assertThat(List.range(1, max + 1).array(Integer[].class), equalTo(ints));
-    }
+  }
 
   @Test
-  public void testSequenceEither() {
+  void integration() {
+    java.util.List<Integer> ul = Arrays.asList(1, 2, 3);
+    List<Integer> dl = List.iterableList(ul);
+    assertTrue(ul.equals(dl.toJavaList()));
+
+  }
+
+  @Test
+  void convertToString() {
+    final int n = 10000;
+    final StringBuilder expected = new StringBuilder("List(");
+    for (int i = 0; i < n; i++) {
+      expected.append(i);
+      if (i < n - 1) {
+        expected.append(',');
+      }
+    }
+    expected.append(')');
+    assertEquals(expected.toString(), List.range(0, n).toString());
+  }
+
+  @Test
+  void partition() {
+    P2<List<Integer>, List<Integer>> p = List.range(1, 5).partition(i -> i % 2 == 0);
+    Equal<List<Integer>> e = Equal.listEqual(Equal.intEqual);
+    assertTrue(e.eq(p._1(), List.list(2, 4)));
+    assertTrue(e.eq(p._2(), List.list(1, 3)));
+  }
+
+  @Test
+  void intersperseOverflow() {
+    // should not overflow
+    int n = 100000;
+    List<Integer> list = List.replicate(n, 1).intersperse(2);
+    String s = list.toString();
+  }
+
+  @Test
+  void listReduce() {
+    String list = List.range(1, 11).uncons((a, la) -> List.cons(a, la).toString(), "");
+    String expected = List.range(1, 11).toString();
+    assertThat(expected, equalTo(list));
+  }
+
+  @Test
+  void array() {
+    final int max = 3;
+    Integer[] ints = new Integer[max];
+    for (int i = 0; i < max; i++) {
+      ints[i] = i + 1;
+    }
+    ;
+    assertThat(List.range(1, max + 1).array(Integer[].class), equalTo(ints));
+  }
+
+  @Test
+  void testSequenceEither() {
     assertEquals(right(nil()), sequenceEither(nil()));
     assertEquals(right(single("zero")), sequenceEither(single(right("zero"))));
     assertEquals(left("zero"), sequenceEither(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceEitherLeft() {
+  void testSequenceEitherLeft() {
     assertEquals(left(nil()), sequenceEitherLeft(nil()));
     assertEquals(left(single("zero")), sequenceEitherLeft(single(left("zero"))));
     assertEquals(right("zero"), sequenceEitherLeft(single(right("zero"))));
   }
 
   @Test
-  public void testSequenceEitherRight() {
+  void testSequenceEitherRight() {
     assertEquals(right(nil()), sequenceEitherRight(nil()));
     assertEquals(right(single("zero")), sequenceEitherRight(single(right("zero"))));
     assertEquals(left("zero"), sequenceEitherRight(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceF() {
+  void testSequenceF() {
     assertEquals(constant(nil()).f(1), sequenceF(nil()).f(1));
     assertEquals(constant(single("zero")).f(1), sequenceF(single(constant("zero"))).f(1));
   }
 
   @Test
-  public void testSequenceIO() throws IOException {
+  void testSequenceIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(nil())).run(), sequenceIO(nil()).run());
     assertEquals(IOFunctions.lazy(constant(single("zero"))).run(), sequenceIO(single(IOFunctions.lazy(constant("zero")))).run());
   }
 
   @Test
-  public void testSequenceList() {
+  void testSequenceList() {
     assertEquals(single(nil()), sequenceList(nil()));
     assertEquals(List.nil(), sequenceList(single(nil())));
     assertEquals(single(single("zero")), sequenceList(single(single("zero"))));
@@ -153,20 +154,20 @@ public class ListTest {
   }
 
   @Test
-  public void testSequenceOption() {
+  void testSequenceOption() {
     assertEquals(some(nil()), sequenceOption(nil()));
     assertEquals(none(), sequenceOption(single(none())));
     assertEquals(some(single("zero")), sequenceOption(single(some("zero"))));
   }
 
   @Test
-  public void testSequenceP1() {
+  void testSequenceP1() {
     assertEquals(p(nil()), sequenceP1(nil()));
     assertEquals(p(single("zero")), sequenceP1(single(p("zero"))));
   }
 
   @Test
-  public void testSequenceSeq() {
+  void testSequenceSeq() {
     assertEquals(Seq.single(nil()), sequenceSeq(nil()));
     assertEquals(Seq.empty(), sequenceSeq(single(Seq.empty())));
     assertEquals(Seq.single(single("zero")), sequenceSeq(single(Seq.single("zero"))));
@@ -174,7 +175,7 @@ public class ListTest {
   }
 
   @Test
-  public void testSequenceSet() {
+  void testSequenceSet() {
     assertEquals(Set.arraySet(listOrd(stringOrd), nil()), sequenceSet(stringOrd, nil()));
     assertEquals(Set.empty(listOrd(stringOrd)), sequenceSet(stringOrd, single(Set.empty(stringOrd))));
     assertEquals(Set.arraySet(listOrd(stringOrd), single("zero")), sequenceSet(stringOrd, single(Set.single(stringOrd, "zero"))));
@@ -182,7 +183,7 @@ public class ListTest {
   }
 
   @Test
-  public void testSequenceStream() {
+  void testSequenceStream() {
     assertEquals(Stream.single(nil()), sequenceStream(nil()));
     assertEquals(Stream.nil(), sequenceStream(single(Stream.nil())));
     assertEquals(Stream.single(single("zero")), sequenceStream(single(Stream.single("zero"))));
@@ -190,20 +191,20 @@ public class ListTest {
   }
 
   @Test
-  public void testSequenceTrampoline() {
+  void testSequenceTrampoline() {
     assertEquals(Trampoline.pure(nil()).run(), sequenceTrampoline(nil()).run());
     assertEquals(Trampoline.pure(single(0)).run(), sequenceTrampoline(single(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     assertEquals(Validation.success(nil()), sequenceValidation(listSemigroup(), nil()));
     assertEquals(Validation.fail(single(0)), sequenceValidation(listSemigroup(), single(Validation.fail(single(0)))));
     assertEquals(Validation.success(single(0)), sequenceValidation(listSemigroup(), single(Validation.success(0))));
   }
 
   @Test
-  public void testTraverseEitherLeft() {
+  void testTraverseEitherLeft() {
     assertEquals(left(nil()), nil().traverseEitherLeft(constant(left(0))));
     assertEquals(left(single(0)), single("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(nil()), nil().traverseEitherLeft(constant(right(0))));
@@ -211,7 +212,7 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseEitherRight() {
+  void testTraverseEitherRight() {
     assertEquals(right(nil()), nil().traverseEitherRight(constant(right(0))));
     assertEquals(right(single(0)), single("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(nil()), nil().traverseEitherRight(constant(left(0))));
@@ -219,19 +220,19 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseF() {
+  void testTraverseF() {
     assertEquals(constant(nil()).f(1), nil().traverseF(constant(constant(0))).f(1));
     assertEquals(constant(single(0)).f(1), single("zero").traverseF(constant(constant(0))).f(1));
   }
 
   @Test
-  public void testTraverseIO() throws IOException {
+  void testTraverseIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(nil())).run(), nil().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(IOFunctions.lazy(constant(single(0))).run(), single("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseList() {
+  void testTraverseList() {
     assertEquals(single(nil()), nil().traverseList(constant(List.nil())));
     assertEquals(List.nil(), single("zero").traverseList(constant(List.nil())));
     assertEquals(single(nil()), nil().traverseList(constant(single(0))));
@@ -241,7 +242,7 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseOption() {
+  void testTraverseOption() {
     assertEquals(some(nil()), nil().traverseOption(constant(none())));
     assertEquals(none(), single("zero").traverseOption(constant(none())));
     assertEquals(some(nil()), nil().traverseOption(constant(some(0))));
@@ -249,13 +250,13 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseP1() {
+  void testTraverseP1() {
     assertEquals(p(nil()), nil().traverseP1(constant(p(0))));
     assertEquals(p(single(0)), single("zero").traverseP1(constant(p(0))));
   }
 
   @Test
-  public void testTraverseSeq() {
+  void testTraverseSeq() {
     assertEquals(Seq.single(nil()), nil().traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.empty(), single("zero").traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.single(nil()), nil().traverseSeq(constant(Seq.single(0))));
@@ -265,7 +266,7 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseSet() {
+  void testTraverseSet() {
     assertEquals(Set.arraySet(listOrd(intOrd), nil()), nil().traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.empty(listOrd(intOrd)), single("zero").traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.single(listOrd(intOrd), nil()), nil().traverseSet(intOrd, constant(Set.single(intOrd, 0))));
@@ -275,7 +276,7 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseStream() {
+  void testTraverseStream() {
     assertEquals(Stream.single(nil()), nil().traverseStream(constant(Stream.nil())));
     assertEquals(Stream.nil(), single("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.single(nil()), nil().traverseStream(constant(Stream.single(0))));
@@ -285,13 +286,13 @@ public class ListTest {
   }
 
   @Test
-  public void testTraverseTrampoline() {
+  void testTraverseTrampoline() {
     assertEquals(Trampoline.pure(nil()).run(), nil().traverseTrampoline(constant(Trampoline.pure(0))).run());
     assertEquals(Trampoline.pure(single(0)).run(), single("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testTraverseValidation() {
+  void testTraverseValidation() {
     assertEquals(success(nil()), nil().traverseValidation(listSemigroup(), constant(Validation.fail(single(0)))));
     assertEquals(fail(single(0)), single("zero").traverseValidation(listSemigroup(), constant(Validation.fail(single(0)))));
     assertEquals(success(nil()), nil().traverseValidation(listSemigroup(), constant(Validation.success(0))));

--- a/core/src/test/java/fj/data/List_Traverse_Tests.java
+++ b/core/src/test/java/fj/data/List_Traverse_Tests.java
@@ -1,8 +1,8 @@
 package fj.data;
 
 import fj.F;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static fj.data.List.list;
 import static fj.data.Option.some;
@@ -12,33 +12,33 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class List_Traverse_Tests {
 
-    @Test
-    public void shouldTraverseListWithGivenFunction(){
-        List<String> strings = list("some1", "some2", "some3", "not_some", "  ");
-        F<String, Option<String>> f = s -> {
-            if(s.startsWith("some"))
-                return some(s);
-            else
-                return Option.none();
-        };
+  @Test
+  void shouldTraverseListWithGivenFunction() {
+    List<String> strings = list("some1", "some2", "some3", "not_some", "  ");
+    F<String, Option<String>> f = s -> {
+      if (s.startsWith("some"))
+        return some(s);
+      else
+        return Option.none();
+    };
 
-        Option<List<String>> optStr = strings.traverseOption(f);
-        Assert.assertEquals("optStr should be none", Option.none(), optStr);
-    }
+    Option<List<String>> optStr = strings.traverseOption(f);
+    Assertions.assertEquals(Option.none(), optStr, "optStr should be none");
+  }
 
-    @Test
-    public void shouldTraverseListWithGivenFunction2(){
-        List<String> strings = list("some1", "some2", "some3");
-        F<String, Option<String>> f = s -> {
-            if(s.startsWith("some"))
-                return some(s);
-            else
-                return Option.none();
-        };
+  @Test
+  void shouldTraverseListWithGivenFunction2() {
+    List<String> strings = list("some1", "some2", "some3");
+    F<String, Option<String>> f = s -> {
+      if (s.startsWith("some"))
+        return some(s);
+      else
+        return Option.none();
+    };
 
-        Option<List<String>> optStr = strings.traverseOption(f);
-        Assert.assertEquals("optStr should be some", optStr.isSome(), true);
-        assertThat(optStr.some(), is(List.list("some1", "some2", "some3")));
-    }
+    Option<List<String>> optStr = strings.traverseOption(f);
+    Assertions.assertEquals(optStr.isSome(), true, "optStr should be some");
+    assertThat(optStr.some(), is(List.list("some1", "some2", "some3")));
+  }
 
 }

--- a/core/src/test/java/fj/data/OptionTest.java
+++ b/core/src/test/java/fj/data/OptionTest.java
@@ -2,9 +2,10 @@ package fj.data;
 
 import fj.P;
 import fj.control.Trampoline;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Function.constant;
 import static fj.Ord.*;
@@ -29,27 +30,28 @@ import static fj.data.Option.sequenceValidation;
 import static fj.data.Option.*;
 import static fj.data.Validation.fail;
 import static fj.data.Validation.*;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class OptionTest {
 
-    @Test
-    public void equals() {
-        int max = 4;
-        assertTrue(some(1).equals(some(1)));
-        assertTrue(some(List.range(1, max)).equals(some(List.range(1, max))));
-    }
-
-    @Test
-    public void traverseList() {
-        int max = 3;
-        List<Option<Integer>> actual = some(max).traverseList(a -> List.range(1, a + 1));
-        List<Option<Integer>> expected = List.range(1, max + 1).map(i -> some(i));
-        assertTrue(actual.equals(expected));
-    }
+  @Test
+  void equals() {
+    int max = 4;
+    assertTrue(some(1).equals(some(1)));
+    assertTrue(some(List.range(1, max)).equals(some(List.range(1, max))));
+  }
 
   @Test
-  public void sequenceListTest() {
+  void traverseList() {
+    int max = 3;
+    List<Option<Integer>> actual = some(max).traverseList(a -> List.range(1, a + 1));
+    List<Option<Integer>> expected = List.range(1, max + 1).map(i -> some(i));
+    assertTrue(actual.equals(expected));
+  }
+
+  @Test
+  void sequenceListTest() {
     assertEquals(some(nil()), sequence(nil()));
     assertEquals(none(), sequence(arrayList(none())));
     assertEquals(some(arrayList(1)), sequence(arrayList(some(1))));
@@ -60,14 +62,14 @@ public final class OptionTest {
   }
 
   @Test
-  public void sequenceValidationTest() {
+  void sequenceValidationTest() {
     assertEquals(some(fail(1)), sequence(Validation.<Integer, Option<String>>fail(1)));
     assertEquals(none(), sequence(Validation.<Integer, Option<String>>success(none())));
     assertEquals(some(success("string")), sequence(Validation.<Integer, Option<String>>success(some("string"))));
   }
 
   @Test
-  public void testBind1() {
+  void testBind1() {
     range(0, 1).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -79,7 +81,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind2() {
+  void testBind2() {
     range(0, 2).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -90,7 +92,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind3() {
+  void testBind3() {
     range(0, 3).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -102,7 +104,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind4() {
+  void testBind4() {
     range(0, 4).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -114,7 +116,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind5() {
+  void testBind5() {
     range(0, 5).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -125,7 +127,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind6() {
+  void testBind6() {
     range(0, 6).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -136,7 +138,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind7() {
+  void testBind7() {
     range(0, 7).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -147,7 +149,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBind8() {
+  void testBind8() {
     range(0, 8).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -158,7 +160,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct2() {
+  void testBindProduct2() {
     range(0, 2).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -169,7 +171,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct3() {
+  void testBindProduct3() {
     range(0, 3).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -181,7 +183,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct4() {
+  void testBindProduct4() {
     range(0, 4).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -193,7 +195,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct5() {
+  void testBindProduct5() {
     range(0, 5).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -204,7 +206,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct6() {
+  void testBindProduct6() {
     range(0, 6).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -215,7 +217,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct7() {
+  void testBindProduct7() {
     range(0, 7).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -226,7 +228,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testBindProduct8() {
+  void testBindProduct8() {
     range(0, 8).map(i -> arrayList(Option.<Integer>none(), some(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -237,40 +239,40 @@ public final class OptionTest {
   }
 
   @Test
-  public void testSequenceEither() {
+  void testSequenceEither() {
     assertEquals(right(none()), sequenceEither(none()));
     assertEquals(right(some("zero")), sequenceEither(some(right("zero"))));
     assertEquals(left("zero"), sequenceEither(some(left("zero"))));
   }
 
   @Test
-  public void testSequenceEitherLeft() {
+  void testSequenceEitherLeft() {
     assertEquals(left(none()), sequenceEitherLeft(none()));
     assertEquals(left(some("zero")), sequenceEitherLeft(some(left("zero"))));
     assertEquals(right("zero"), sequenceEitherLeft(some(right("zero"))));
   }
 
   @Test
-  public void testSequenceEitherRight() {
+  void testSequenceEitherRight() {
     assertEquals(right(none()), sequenceEitherRight(none()));
     assertEquals(right(some("zero")), sequenceEitherRight(some(right("zero"))));
     assertEquals(left("zero"), sequenceEitherRight(some(left("zero"))));
   }
 
   @Test
-  public void testSequenceF() {
+  void testSequenceF() {
     assertEquals(constant(none()).f(1), sequenceF(none()).f(1));
     assertEquals(constant(some("zero")).f(1), sequenceF(some(constant("zero"))).f(1));
   }
 
   @Test
-  public void testSequenceIO() throws IOException {
+  void testSequenceIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(none())).run(), sequenceIO(none()).run());
     assertEquals(IOFunctions.lazy(constant(some("zero"))).run(), sequenceIO(some(IOFunctions.lazy(constant("zero")))).run());
   }
 
   @Test
-  public void testSequenceList() {
+  void testSequenceList() {
     assertEquals(List.single(none()), sequenceList(none()));
     assertEquals(List.nil(), sequenceList(some(List.nil())));
     assertEquals(List.single(some("zero")), sequenceList(some(List.single("zero"))));
@@ -278,20 +280,20 @@ public final class OptionTest {
   }
 
   @Test
-  public void testSequenceOption() {
+  void testSequenceOption() {
     assertEquals(some(none()), sequenceOption(none()));
     assertEquals(none(), sequenceOption(some(none())));
     assertEquals(some(some("zero")), sequenceOption(some(some("zero"))));
   }
 
   @Test
-  public void testSequenceP1() {
+  void testSequenceP1() {
     assertEquals(p(none()), sequenceP1(none()));
     assertEquals(p(some("zero")), sequenceP1(some(p("zero"))));
   }
 
   @Test
-  public void testSequenceSeq() {
+  void testSequenceSeq() {
     assertEquals(Seq.single(none()), sequenceSeq(none()));
     assertEquals(Seq.empty(), sequenceSeq(some(Seq.empty())));
     assertEquals(Seq.single(some("zero")), sequenceSeq(some(Seq.single("zero"))));
@@ -299,7 +301,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testSequenceSet() {
+  void testSequenceSet() {
     assertEquals(Set.arraySet(optionOrd(stringOrd), none()), sequenceSet(stringOrd, none()));
     assertEquals(Set.empty(optionOrd(stringOrd)), sequenceSet(stringOrd, some(Set.empty(stringOrd))));
     assertEquals(Set.arraySet(optionOrd(stringOrd), some("zero")), sequenceSet(stringOrd, some(Set.single(stringOrd, "zero"))));
@@ -307,7 +309,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testSequenceStream() {
+  void testSequenceStream() {
     assertEquals(Stream.single(none()), sequenceStream(none()));
     assertEquals(Stream.nil(), sequenceStream(some(Stream.nil())));
     assertEquals(Stream.single(some("zero")), sequenceStream(some(Stream.single("zero"))));
@@ -315,20 +317,20 @@ public final class OptionTest {
   }
 
   @Test
-  public void testSequenceTrampoline() {
+  void testSequenceTrampoline() {
     assertEquals(Trampoline.pure(none()).run(), sequenceTrampoline(none()).run());
     assertEquals(Trampoline.pure(some(0)).run(), sequenceTrampoline(some(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     assertEquals(Validation.success(none()), sequenceValidation(none()));
     assertEquals(Validation.fail(0), sequenceValidation(some(Validation.fail(0))));
     assertEquals(Validation.success(some(0)), sequenceValidation(some(Validation.success(0))));
   }
 
   @Test
-  public void testTraverseEither() {
+  void testTraverseEither() {
     assertEquals(right(none()), none().traverseEither(constant(right(0))));
     assertEquals(right(some(0)), some("zero").traverseEither(constant(right(0))));
     assertEquals(right(none()), none().traverseEither(constant(left(0))));
@@ -336,7 +338,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseEitherLeft() {
+  void testTraverseEitherLeft() {
     assertEquals(left(none()), none().traverseEitherLeft(constant(left(0))));
     assertEquals(left(some(0)), some("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(none()), none().traverseEitherLeft(constant(right(0))));
@@ -344,7 +346,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseEitherRight() {
+  void testTraverseEitherRight() {
     assertEquals(right(none()), none().traverseEitherRight(constant(right(0))));
     assertEquals(right(some(0)), some("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(none()), none().traverseEitherRight(constant(left(0))));
@@ -352,19 +354,19 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseF() {
+  void testTraverseF() {
     assertEquals(constant(none()).f(1), none().traverseF(constant(constant(0))).f(1));
     assertEquals(constant(some(0)).f(1), some("zero").traverseF(constant(constant(0))).f(1));
   }
 
   @Test
-  public void testTraverseIO() throws IOException {
+  void testTraverseIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(none())).run(), none().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(IOFunctions.lazy(constant(some(0))).run(), some("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseList() {
+  void testTraverseList() {
     assertEquals(List.single(none()), none().traverseList(constant(List.nil())));
     assertEquals(List.nil(), some("zero").traverseList(constant(List.nil())));
     assertEquals(List.single(none()), none().traverseList(constant(List.single(0))));
@@ -374,7 +376,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseOption() {
+  void testTraverseOption() {
     assertEquals(some(none()), none().traverseOption(constant(none())));
     assertEquals(none(), some("zero").traverseOption(constant(none())));
     assertEquals(some(none()), none().traverseOption(constant(some(0))));
@@ -382,13 +384,13 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseP1() {
+  void testTraverseP1() {
     assertEquals(p(none()), none().traverseP1(constant(p(0))));
     assertEquals(p(some(0)), some("zero").traverseP1(constant(p(0))));
   }
 
   @Test
-  public void testTraverseSeq() {
+  void testTraverseSeq() {
     assertEquals(Seq.single(none()), none().traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.empty(), some("zero").traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.single(none()), none().traverseSeq(constant(Seq.single(0))));
@@ -398,7 +400,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseSet() {
+  void testTraverseSet() {
     assertEquals(Set.arraySet(optionOrd(intOrd), none()), none().traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.empty(optionOrd(intOrd)), some("zero").traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.arraySet(optionOrd(intOrd), none()), none().traverseSet(intOrd, constant(Set.single(intOrd, 0))));
@@ -408,7 +410,7 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseStream() {
+  void testTraverseStream() {
     assertEquals(Stream.single(none()), none().traverseStream(constant(Stream.nil())));
     assertEquals(Stream.nil(), some("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.single(none()), none().traverseStream(constant(Stream.single(0))));
@@ -418,13 +420,13 @@ public final class OptionTest {
   }
 
   @Test
-  public void testTraverseTrampoline() {
+  void testTraverseTrampoline() {
     assertEquals(Trampoline.pure(none()).run(), none().traverseTrampoline(constant(Trampoline.pure(0))).run());
     assertEquals(Trampoline.pure(some(0)).run(), some("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testTraverseValidation() {
+  void testTraverseValidation() {
     assertEquals(success(none()), none().traverseValidation(constant(Validation.fail(0))));
     assertEquals(fail(0), some("zero").traverseValidation(constant(Validation.fail(0))));
     assertEquals(success(none()), none().traverseValidation(constant(Validation.success(0))));

--- a/core/src/test/java/fj/data/SeqTest.java
+++ b/core/src/test/java/fj/data/SeqTest.java
@@ -2,9 +2,10 @@ package fj.data;
 
 import fj.P2;
 import fj.control.Trampoline;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Function.constant;
 import static fj.Ord.*;
@@ -31,44 +32,44 @@ import static fj.data.Validation.fail;
 import static fj.data.Validation.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SeqTest {
 
-    @Test
-    public void objectMethods() {
-        Seq<Integer> s1 = Seq.seq(1, 2, 3);
-        Seq<Integer> s2 = Seq.seq(1, 2, 3);
-        assertTrue(s1.toString().equals("Seq(1,2,3)"));
-        assertTrue(s1.equals(s2));
-        assertFalse(s1 == s2);
+  @Test
+  void objectMethods() {
+    Seq<Integer> s1 = Seq.seq(1, 2, 3);
+    Seq<Integer> s2 = Seq.seq(1, 2, 3);
+    assertTrue(s1.toString().equals("Seq(1,2,3)"));
+    assertTrue(s1.equals(s2));
+    assertFalse(s1 == s2);
 
-    }
-
-    @Test
-    public void convertToString() {
-        final int n = 10000;
-        final StringBuilder expected = new StringBuilder("Seq(");
-        for (int i = 0; i < n; i++) {
-            expected.append(i);
-            if (i < n - 1) {
-                expected.append(',');
-            }
-        }
-        expected.append(')');
-        assertEquals(expected.toString(), Seq.seq(Array.range(0, 10000).array()).toString());
-    }
-
-
-    @Test
-    public void test() {
-        P2<Seq<Integer>, Seq<Integer>> p2 = Seq.single(1).split(5);
-        assertThat(p2._1(), is(Seq.single(1)));
-        assertThat(p2._2(), is(Seq.empty()));
-    }
+  }
 
   @Test
-  public void testBind() {
+  void convertToString() {
+    final int n = 10000;
+    final StringBuilder expected = new StringBuilder("Seq(");
+    for (int i = 0; i < n; i++) {
+      expected.append(i);
+      if (i < n - 1) {
+        expected.append(',');
+      }
+    }
+    expected.append(')');
+    assertEquals(expected.toString(), Seq.seq(Array.range(0, 10000).array()).toString());
+  }
+
+
+  @Test
+  void test() {
+    P2<Seq<Integer>, Seq<Integer>> p2 = Seq.single(1).split(5);
+    assertThat(p2._1(), is(Seq.single(1)));
+    assertThat(p2._2(), is(Seq.empty()));
+  }
+
+  @Test
+  void testBind() {
     assertEquals(empty(), empty().bind(constant(empty())));
     assertEquals(empty(), empty().bind(constant(single(0))));
     assertEquals(empty(), empty().bind(constant(arraySeq(0, 1))));
@@ -81,40 +82,40 @@ public class SeqTest {
   }
 
   @Test
-  public void testSequenceEither() {
+  void testSequenceEither() {
     assertEquals(right(empty()), sequenceEither(empty()));
     assertEquals(right(single("zero")), sequenceEither(single(right("zero"))));
     assertEquals(left("zero"), sequenceEither(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceEitherLeft() {
+  void testSequenceEitherLeft() {
     assertEquals(left(empty()), sequenceEitherLeft(empty()));
     assertEquals(left(single("zero")), sequenceEitherLeft(single(left("zero"))));
     assertEquals(right("zero"), sequenceEitherLeft(single(right("zero"))));
   }
 
   @Test
-  public void testSequenceEitherRight() {
+  void testSequenceEitherRight() {
     assertEquals(right(empty()), sequenceEitherRight(empty()));
     assertEquals(right(single("zero")), sequenceEitherRight(single(right("zero"))));
     assertEquals(left("zero"), sequenceEitherRight(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceF() {
+  void testSequenceF() {
     assertEquals(constant(empty()).f(1), sequenceF(empty()).f(1));
     assertEquals(constant(single("zero")).f(1), sequenceF(single(constant("zero"))).f(1));
   }
 
   @Test
-  public void testSequenceIO() throws IOException {
+  void testSequenceIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(empty())).run(), sequenceIO(empty()).run());
     assertEquals(IOFunctions.lazy(constant(single("zero"))).run(), sequenceIO(single(IOFunctions.lazy(constant("zero")))).run());
   }
 
   @Test
-  public void testSequenceList() {
+  void testSequenceList() {
     assertEquals(List.single(empty()), sequenceList(empty()));
     assertEquals(List.nil(), sequenceList(single(List.nil())));
     assertEquals(List.single(single("zero")), sequenceList(single(List.single("zero"))));
@@ -122,20 +123,20 @@ public class SeqTest {
   }
 
   @Test
-  public void testSequenceOption() {
+  void testSequenceOption() {
     assertEquals(some(empty()), sequenceOption(empty()));
     assertEquals(none(), sequenceOption(single(none())));
     assertEquals(some(single("zero")), sequenceOption(single(some("zero"))));
   }
 
   @Test
-  public void testSequenceP1() {
+  void testSequenceP1() {
     assertEquals(p(empty()), sequenceP1(empty()));
     assertEquals(p(single("zero")), sequenceP1(single(p("zero"))));
   }
 
   @Test
-  public void testSequenceSeq() {
+  void testSequenceSeq() {
     assertEquals(single(empty()), sequenceSeq(empty()));
     assertEquals(empty(), sequenceSeq(single(empty())));
     assertEquals(single(single("zero")), sequenceSeq(single(single("zero"))));
@@ -143,7 +144,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testSequenceSet() {
+  void testSequenceSet() {
     assertEquals(Set.arraySet(seqOrd(stringOrd), empty()), sequenceSet(stringOrd, empty()));
     assertEquals(Set.empty(seqOrd(stringOrd)), sequenceSet(stringOrd, single(Set.empty(stringOrd))));
     assertEquals(Set.arraySet(seqOrd(stringOrd), single("zero")), sequenceSet(stringOrd, single(Set.single(stringOrd, "zero"))));
@@ -151,7 +152,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testSequenceStream() {
+  void testSequenceStream() {
     assertEquals(Stream.single(empty()), sequenceStream(empty()));
     assertEquals(Stream.nil(), sequenceStream(single(Stream.nil())));
     assertEquals(Stream.single(single("zero")), sequenceStream(single(Stream.single("zero"))));
@@ -159,27 +160,27 @@ public class SeqTest {
   }
 
   @Test
-  public void testSequenceTrampoline() {
+  void testSequenceTrampoline() {
     assertEquals(Trampoline.pure(empty()).run(), sequenceTrampoline(empty()).run());
     assertEquals(Trampoline.pure(single(0)).run(), sequenceTrampoline(single(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     assertEquals(success(empty()), sequenceValidation(empty()));
     assertEquals(fail(single(0)), sequenceValidation(single(fail(single(0)))));
     assertEquals(success(single(0)), sequenceValidation(single(success(0))));
   }
 
   @Test
-  public void testSequenceValidationSemigroup() {
+  void testSequenceValidationSemigroup() {
     assertEquals(success(empty()), sequenceValidation(listSemigroup(), empty()));
     assertEquals(fail(List.single(0)), sequenceValidation(listSemigroup(), single(fail(List.single(0)))));
     assertEquals(success(single(0)), sequenceValidation(listSemigroup(), single(success(0))));
   }
 
   @Test
-  public void testTraverseEitherLeft() {
+  void testTraverseEitherLeft() {
     assertEquals(left(empty()), empty().traverseEitherLeft(constant(left(0))));
     assertEquals(left(single(0)), single("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(empty()), empty().traverseEitherLeft(constant(right(0))));
@@ -187,7 +188,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseEitherRight() {
+  void testTraverseEitherRight() {
     assertEquals(right(empty()), empty().traverseEitherRight(constant(right(0))));
     assertEquals(right(single(0)), single("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(empty()), empty().traverseEitherRight(constant(left(0))));
@@ -195,19 +196,19 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseF() {
+  void testTraverseF() {
     assertEquals(constant(empty()).f(1), empty().traverseF(constant(constant(0))).f(1));
     assertEquals(constant(single(0)).f(1), single("zero").traverseF(constant(constant(0))).f(1));
   }
 
   @Test
-  public void testTraverseIO() throws IOException {
+  void testTraverseIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(empty())).run(), empty().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(IOFunctions.lazy(constant(single(0))).run(), single("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseList() {
+  void testTraverseList() {
     assertEquals(List.single(empty()), empty().traverseList(constant(List.nil())));
     assertEquals(List.nil(), single("zero").traverseList(constant(List.nil())));
     assertEquals(List.single(empty()), empty().traverseList(constant(List.single(0))));
@@ -217,7 +218,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseOption() {
+  void testTraverseOption() {
     assertEquals(some(empty()), empty().traverseOption(constant(none())));
     assertEquals(none(), single("zero").traverseOption(constant(none())));
     assertEquals(some(empty()), empty().traverseOption(constant(some(0))));
@@ -225,13 +226,13 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseP1() {
+  void testTraverseP1() {
     assertEquals(p(empty()), empty().traverseP1(constant(p(0))));
     assertEquals(p(single(0)), single("zero").traverseP1(constant(p(0))));
   }
 
   @Test
-  public void testTraverseSeq() {
+  void testTraverseSeq() {
     assertEquals(single(empty()), empty().traverseSeq(constant(empty())));
     assertEquals(empty(), single("zero").traverseSeq(constant(empty())));
     assertEquals(single(empty()), empty().traverseSeq(constant(single(0))));
@@ -241,7 +242,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseSet() {
+  void testTraverseSet() {
     assertEquals(Set.arraySet(seqOrd(intOrd), empty()), empty().traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.empty(seqOrd(intOrd)), single("zero").traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.single(seqOrd(intOrd), empty()), empty().traverseSet(intOrd, constant(Set.single(intOrd, 0))));
@@ -251,7 +252,7 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseStream() {
+  void testTraverseStream() {
     assertEquals(Stream.single(empty()), empty().traverseStream(constant(Stream.nil())));
     assertEquals(Stream.nil(), single("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.single(empty()), empty().traverseStream(constant(Stream.single(0))));
@@ -261,30 +262,30 @@ public class SeqTest {
   }
 
   @Test
-  public void testTraverseTrampoline() {
+  void testTraverseTrampoline() {
     assertEquals(Trampoline.pure(empty()).run(), empty().traverseTrampoline(constant(Trampoline.pure(0))).run());
     assertEquals(Trampoline.pure(single(0)).run(), single("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testTraverseValidation() {
+  void testTraverseValidation() {
     assertEquals(success(empty()), empty().traverseValidation(constant(fail(single(0)))));
     assertEquals(fail(single(0)), single("zero").traverseValidation(constant(fail(single(0)))));
     assertEquals(success(empty()), empty().traverseValidation(constant(success(0))));
     assertEquals(success(single(0)), single("zero").traverseValidation(constant(success(0))));
 
-    assertEquals(success(arraySeq(0, 2, 4, 6, 8)), arraySeq(0, 2, 4, 6, 8).traverseValidation(i -> condition(i% 2 == 0, List.single(i), i)));
-    assertEquals(fail(List.single(1)), arraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).traverseValidation(i -> condition(i% 2 == 0, List.single(i), i)));
+    assertEquals(success(arraySeq(0, 2, 4, 6, 8)), arraySeq(0, 2, 4, 6, 8).traverseValidation(i -> condition(i % 2 == 0, List.single(i), i)));
+    assertEquals(fail(List.single(1)), arraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).traverseValidation(i -> condition(i % 2 == 0, List.single(i), i)));
   }
 
   @Test
-  public void testTraverseValidationSemigroup() {
+  void testTraverseValidationSemigroup() {
     assertEquals(success(empty()), empty().traverseValidation(listSemigroup(), constant(fail(List.single(0)))));
     assertEquals(fail(List.single(0)), single("zero").traverseValidation(listSemigroup(), constant(fail(List.single(0)))));
     assertEquals(success(empty()), empty().traverseValidation(listSemigroup(), constant(success(0))));
     assertEquals(success(single(0)), single("zero").traverseValidation(listSemigroup(), constant(success(0))));
 
-    assertEquals(success(arraySeq(0, 2, 4, 6, 8)), arraySeq(0, 2, 4, 6, 8).traverseValidation(listSemigroup(),i -> condition(i% 2 == 0, List.single(i), i)));
-    assertEquals(fail(arrayList(1, 3, 5, 7, 9)), arraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).traverseValidation(listSemigroup(),i -> condition(i% 2 == 0, List.single(i), i)));
+    assertEquals(success(arraySeq(0, 2, 4, 6, 8)), arraySeq(0, 2, 4, 6, 8).traverseValidation(listSemigroup(), i -> condition(i % 2 == 0, List.single(i), i)));
+    assertEquals(fail(arrayList(1, 3, 5, 7, 9)), arraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).traverseValidation(listSemigroup(), i -> condition(i % 2 == 0, List.single(i), i)));
   }
 }

--- a/core/src/test/java/fj/data/SetTest.java
+++ b/core/src/test/java/fj/data/SetTest.java
@@ -1,39 +1,40 @@
 package fj.data;
 
-import org.junit.Test;
-
 import static fj.data.Option.none;
 import static fj.data.Option.some;
+
+import org.junit.jupiter.api.Test;
+
 import static fj.Ord.intOrd;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SetTest {
 
-	@Test
-	public void toStream() {
-		Set<Integer> s = Set.set(intOrd, 1, 2, 3);
-		assertThat(s.toStream(), equalTo(Stream.stream(1, 2, 3)));
-	}
+  @Test
+  void toStream() {
+    Set<Integer> s = Set.set(intOrd, 1, 2, 3);
+    assertThat(s.toStream(), equalTo(Stream.stream(1, 2, 3)));
+  }
 
-	@Test
-	public void testString() {
-		Set<Integer> s = Set.set(intOrd, 1, 2, 3);
-		assertThat(s.toString(), equalTo("Set(1,2,3)"));
-	}
+  @Test
+  void testString() {
+    Set<Integer> s = Set.set(intOrd, 1, 2, 3);
+    assertThat(s.toString(), equalTo("Set(1,2,3)"));
+  }
 
-	@Test
-	public void testLookups() {
-		Set<Integer> s = Set.set(intOrd, 5, 1, 7, 8);
-		assertThat(s.lookup(7), equalTo(some(7)));
-		assertThat(s.lookup(4), equalTo(none()));
-		assertThat(s.lookupLT(6), equalTo(some(5)));
-		assertThat(s.lookupLT(1), equalTo(none()));
-		assertThat(s.lookupGT(5), equalTo(some(7)));
-		assertThat(s.lookupGT(9), equalTo(none()));
-		assertThat(s.lookupLE(8), equalTo(some(8)));
-		assertThat(s.lookupLE(0), equalTo(none()));
-		assertThat(s.lookupGE(8), equalTo(some(8)));
-		assertThat(s.lookupGE(9), equalTo(none()));
-	}
+  @Test
+  void testLookups() {
+    Set<Integer> s = Set.set(intOrd, 5, 1, 7, 8);
+    assertThat(s.lookup(7), equalTo(some(7)));
+    assertThat(s.lookup(4), equalTo(none()));
+    assertThat(s.lookupLT(6), equalTo(some(5)));
+    assertThat(s.lookupLT(1), equalTo(none()));
+    assertThat(s.lookupGT(5), equalTo(some(7)));
+    assertThat(s.lookupGT(9), equalTo(none()));
+    assertThat(s.lookupLE(8), equalTo(some(8)));
+    assertThat(s.lookupLE(0), equalTo(none()));
+    assertThat(s.lookupGE(8), equalTo(some(8)));
+    assertThat(s.lookupGE(9), equalTo(none()));
+  }
 }

--- a/core/src/test/java/fj/data/StateTest.java
+++ b/core/src/test/java/fj/data/StateTest.java
@@ -1,14 +1,15 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.P.p;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StateTest {
 
   @Test
-  public void testBind() {
+  void testBind() {
     assertEquals(p(2, "one"), state().run(1));
     assertEquals(p(3, "two"), state().run(2));
     assertEquals(p(4, "three"), state().run(3));
@@ -18,7 +19,7 @@ public class StateTest {
   }
 
   @Test
-  public void testFlatMap() {
+  void testFlatMap() {
     assertEquals(p(2, "one"), state().run(1));
     assertEquals(p(3, "two"), state().run(2));
     assertEquals(p(4, "three"), state().run(3));

--- a/core/src/test/java/fj/data/StreamTest.java
+++ b/core/src/test/java/fj/data/StreamTest.java
@@ -3,9 +3,10 @@ package fj.data;
 import fj.Equal;
 import fj.P2;
 import fj.control.Trampoline;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 import java.util.ConcurrentModificationException;
 
 import static fj.Function.constant;
@@ -35,135 +36,144 @@ import static fj.data.Stream.*;
 import static fj.data.Validation.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StreamTest {
 
   @Test
-  public void infiniteStream() {
+  void infiniteStream() {
     Stream<Integer> s = Stream.forever(Enumerator.intEnumerator, 0).bind(Stream::single);
     assertThat(List.range(0, 5), is(s.take(5).toList()));
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     Stream<Integer> range = Stream.range(1);
     assertThat(range.toString(), is(equalTo("Cons(1, ?)")));
   }
 
-    /**
-     * This test demonstrates the known problem of creating streams from mutable structures.
-     *
-     * Some of the ways streams created in this way can fail is:
-     * - weak stream references getting garbage collected
-     * - underlying mutable data structure changes
-     * - iterator gets updated (e.g. iterator used to create 2 different streams).
-     */
-    @Test(expected = ConcurrentModificationException.class)
-    public void iterableStreamWithStructureUpdate() {
-        java.util.List<Integer> list = List.list(1, 2, 3).toJavaList();
-        Stream<Integer> s1 = Stream.iterableStream(list);
-        int x = s1.head();
-        list.remove(1);
-        Stream<Integer> s2 = s1.tail()._1();
-        x = s2.head();
-    }
-
-    @Test(expected=Error.class)
-    public void testCycleNil(){
-        cycle(Stream.nil());
-    }
-
-    @Test
-    public void testCycle() {
-        Stream<Character> s = stream(new Character[]{'a', 'b'});
-        assertThat(cycle(s).take(5),
-                is(stream(new Character[]{'a', 'b', 'a', 'b', 'a'})));
-    }
-
-    @Test
-    public void testIterate() {
-        assertThat(iterate(a -> 2 * a + 1, 1).take(5),
-                is(stream(new Integer[]{1, 3, 7, 15, 31})));
-    }
-
-    @Test
-    public void testArrayStreamEmpty() {
-        assertThat(arrayStream(new Integer[]{}), is(Stream.nil()));
-    }
-
-    @Test(expected=Error.class)
-    public void testNilHead() {
-        Stream.nil().head();
-    }
-
-    @Test(expected=Error.class)
-    public void testNilTail() {
-        Stream.nil().tail();
-    }
-
-    @Test
-    public void testArray() {
-        Character[] a = new Character[]{'a', 'b', 'c'};
-        Stream<Character> s = stream(a);
-        assertThat(s.array(Character[].class), is(a));
-    }
-
-    @Test
-    public void testZipIndex() {
-        Character[] a = new Character[]{'a', 'b', 'c'};
-        P2<Stream<Character>, Stream<Integer>> p = unzip(stream(a).zipIndex().drop(1));
-        assertThat(p._1(), is(stream(new Character[]{'b', 'c'})));
-        assertThat(p._2(), is(stream(new Integer[]{1, 2})));
-    }
-
-    @Test
-    public void testMinus() {
-        Character[] a1 = new Character[]{'a', 'b', 'c', 'd', 'e'};
-        Stream<Character> s1 = stream(a1);
-        Character[] a2 = new Character[]{'b', 'e'};
-        Stream<Character> s2 = stream(a2);
-        assertThat(s1.minus(Equal.charEqual, s2),
-                is(stream(new Character[]{'a', 'c', 'd'})));
-    }
+  /**
+   * This test demonstrates the known problem of creating streams from mutable structures.
+   *
+   * Some of the ways streams created in this way can fail is:
+   * - weak stream references getting garbage collected
+   * - underlying mutable data structure changes
+   * - iterator gets updated (e.g. iterator used to create 2 different streams).
+   */
+  @Test
+  void iterableStreamWithStructureUpdate() {
+    assertThrows(ConcurrentModificationException.class, () -> {
+      java.util.List<Integer> list = List.list(1, 2, 3).toJavaList();
+      Stream<Integer> s1 = Stream.iterableStream(list);
+      int x = s1.head();
+      list.remove(1);
+      Stream<Integer> s2 = s1.tail()._1();
+      x = s2.head();
+    });
+  }
 
   @Test
-  public void testSequenceEither() {
+  void testCycleNil() {
+    assertThrows(Error.class, () -> {
+      cycle(Stream.nil());
+    });
+  }
+
+  @Test
+  void testCycle() {
+    Stream<Character> s = stream(new Character[]{'a', 'b'});
+    assertThat(cycle(s).take(5),
+        is(stream(new Character[]{'a', 'b', 'a', 'b', 'a'})));
+  }
+
+  @Test
+  void testIterate() {
+    assertThat(iterate(a -> 2 * a + 1, 1).take(5),
+        is(stream(new Integer[]{1, 3, 7, 15, 31})));
+  }
+
+  @Test
+  void testArrayStreamEmpty() {
+    assertThat(arrayStream(new Integer[]{}), is(Stream.nil()));
+  }
+
+  @Test
+  void testNilHead() {
+    assertThrows(Error.class, () -> {
+      Stream.nil().head();
+    });
+  }
+
+  @Test
+  void testNilTail() {
+    assertThrows(Error.class, () -> {
+      Stream.nil().tail();
+    });
+  }
+
+  @Test
+  void testArray() {
+    Character[] a = new Character[]{'a', 'b', 'c'};
+    Stream<Character> s = stream(a);
+    assertThat(s.array(Character[].class), is(a));
+  }
+
+  @Test
+  void testZipIndex() {
+    Character[] a = new Character[]{'a', 'b', 'c'};
+    P2<Stream<Character>, Stream<Integer>> p = unzip(stream(a).zipIndex().drop(1));
+    assertThat(p._1(), is(stream(new Character[]{'b', 'c'})));
+    assertThat(p._2(), is(stream(new Integer[]{1, 2})));
+  }
+
+  @Test
+  void testMinus() {
+    Character[] a1 = new Character[]{'a', 'b', 'c', 'd', 'e'};
+    Stream<Character> s1 = stream(a1);
+    Character[] a2 = new Character[]{'b', 'e'};
+    Stream<Character> s2 = stream(a2);
+    assertThat(s1.minus(Equal.charEqual, s2),
+        is(stream(new Character[]{'a', 'c', 'd'})));
+  }
+
+  @Test
+  void testSequenceEither() {
     assertEquals(right(nil()), sequenceEither(nil()));
     assertEquals(right(single("zero")), sequenceEither(single(right("zero"))));
     assertEquals(left("zero"), sequenceEither(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceEitherLeft() {
+  void testSequenceEitherLeft() {
     assertEquals(left(nil()), sequenceEitherLeft(nil()));
     assertEquals(left(single("zero")), sequenceEitherLeft(single(left("zero"))));
     assertEquals(right("zero"), sequenceEitherLeft(single(right("zero"))));
   }
 
   @Test
-  public void testSequenceEitherRight() {
+  void testSequenceEitherRight() {
     assertEquals(right(nil()), sequenceEitherRight(nil()));
     assertEquals(right(single("zero")), sequenceEitherRight(single(right("zero"))));
     assertEquals(left("zero"), sequenceEitherRight(single(left("zero"))));
   }
 
   @Test
-  public void testSequenceF() {
+  void testSequenceF() {
     assertEquals(constant(nil()).f(1), sequenceF(nil()).f(1));
     assertEquals(constant(single("zero")).f(1), sequenceF(single(constant("zero"))).f(1));
   }
 
   @Test
-  public void testSequenceIO()
-          throws IOException {
+  void testSequenceIO()
+      throws IOException {
     assertEquals(IOFunctions.lazy(constant(nil())).run(), sequenceIO(nil()).run());
     assertEquals(IOFunctions.lazy(constant(single("zero"))).run(), sequenceIO(single(IOFunctions.lazy(constant("zero")))).run());
   }
 
   @Test
-  public void testSequenceList() {
+  void testSequenceList() {
     assertEquals(List.single(nil()), sequenceList(nil()));
     assertEquals(List.nil(), sequenceList(single(List.nil())));
     assertEquals(List.single(single("zero")), sequenceList(single(List.single("zero"))));
@@ -171,20 +181,20 @@ public class StreamTest {
   }
 
   @Test
-  public void testSequenceOption() {
+  void testSequenceOption() {
     assertEquals(some(nil()), sequenceOption(nil()));
     assertEquals(none(), sequenceOption(single(none())));
     assertEquals(some(single("zero")), sequenceOption(single(some("zero"))));
   }
 
   @Test
-  public void testSequenceP1() {
+  void testSequenceP1() {
     assertEquals(p(nil()), sequenceP1(nil()));
     assertEquals(p(single("zero")), sequenceP1(single(p("zero"))));
   }
 
   @Test
-  public void testSequenceSeq() {
+  void testSequenceSeq() {
     assertEquals(Seq.single(nil()), sequenceSeq(nil()));
     assertEquals(Seq.empty(), sequenceSeq(single(Seq.empty())));
     assertEquals(Seq.single(single("zero")), sequenceSeq(single(Seq.single("zero"))));
@@ -192,7 +202,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testSequenceSet() {
+  void testSequenceSet() {
     assertEquals(Set.arraySet(streamOrd(stringOrd), nil()), sequenceSet(stringOrd, nil()));
     assertEquals(Set.empty(streamOrd(stringOrd)), sequenceSet(stringOrd, single(Set.empty(stringOrd))));
     assertEquals(Set.arraySet(streamOrd(stringOrd), single("zero")), sequenceSet(stringOrd, single(Set.single(stringOrd, "zero"))));
@@ -200,7 +210,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testSequenceStream() {
+  void testSequenceStream() {
     assertEquals(single(nil()), sequenceStream(nil()));
     assertEquals(nil(), sequenceStream(single(nil())));
     assertEquals(single(single("zero")), sequenceStream(single(single("zero"))));
@@ -208,27 +218,27 @@ public class StreamTest {
   }
 
   @Test
-  public void testSequenceTrampoline() {
+  void testSequenceTrampoline() {
     assertEquals(Trampoline.pure(nil()).run(), sequenceTrampoline(nil()).run());
     assertEquals(Trampoline.pure(single(0)).run(), sequenceTrampoline(single(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     assertEquals(success(nil()), sequenceValidation(nil()));
     assertEquals(fail(single(0)), sequenceValidation(single(fail(single(0)))));
     assertEquals(success(single(0)), sequenceValidation(single(success(0))));
   }
 
   @Test
-  public void testSequenceValidationSemigroup() {
+  void testSequenceValidationSemigroup() {
     assertEquals(success(nil()), sequenceValidation(listSemigroup(), nil()));
     assertEquals(fail(List.single(0)), sequenceValidation(listSemigroup(), single(fail(List.single(0)))));
     assertEquals(success(single(0)), sequenceValidation(listSemigroup(), single(success(0))));
   }
 
   @Test
-  public void testTraverseEitherLeft() {
+  void testTraverseEitherLeft() {
     assertEquals(left(nil()), nil().traverseEitherLeft(constant(left(0))));
     assertEquals(left(single(0)), single("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(nil()), nil().traverseEitherLeft(constant(right(0))));
@@ -236,7 +246,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseEitherRight() {
+  void testTraverseEitherRight() {
     assertEquals(right(nil()), nil().traverseEitherRight(constant(right(0))));
     assertEquals(right(single(0)), single("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(nil()), nil().traverseEitherRight(constant(left(0))));
@@ -244,20 +254,20 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseF() {
+  void testTraverseF() {
     assertEquals(constant(nil()).f(1), nil().traverseF(constant(constant(0))).f(1));
     assertEquals(constant(single(0)).f(1), single("zero").traverseF(constant(constant(0))).f(1));
   }
 
   @Test
-  public void testTraverseIO()
-          throws IOException {
+  void testTraverseIO()
+      throws IOException {
     assertEquals(IOFunctions.lazy(constant(nil())).run(), nil().traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(IOFunctions.lazy(constant(single(0))).run(), single("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseList() {
+  void testTraverseList() {
     assertEquals(List.single(nil()), nil().traverseList(constant(List.nil())));
     assertEquals(List.nil(), single("zero").traverseList(constant(List.nil())));
     assertEquals(List.single(nil()), nil().traverseList(constant(List.single(0))));
@@ -267,7 +277,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseOption() {
+  void testTraverseOption() {
     assertEquals(some(nil()), nil().traverseOption(constant(none())));
     assertEquals(none(), single("zero").traverseOption(constant(none())));
     assertEquals(some(nil()), nil().traverseOption(constant(some(0))));
@@ -275,13 +285,13 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseP1() {
+  void testTraverseP1() {
     assertEquals(p(nil()), nil().traverseP1(constant(p(0))));
     assertEquals(p(single(0)), single("zero").traverseP1(constant(p(0))));
   }
 
   @Test
-  public void testTraverseSeq() {
+  void testTraverseSeq() {
     assertEquals(Seq.single(nil()), nil().traverseSeq(constant(empty())));
     assertEquals(Seq.empty(), single("zero").traverseSeq(constant(empty())));
     assertEquals(Seq.single(nil()), nil().traverseSeq(constant(Seq.single(0))));
@@ -291,7 +301,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseSet() {
+  void testTraverseSet() {
     assertEquals(Set.arraySet(streamOrd(intOrd), nil()), nil().traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.empty(streamOrd(intOrd)), single("zero").traverseSet(intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.single(streamOrd(intOrd), nil()), nil().traverseSet(intOrd, constant(Set.single(intOrd, 0))));
@@ -301,7 +311,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseStream() {
+  void testTraverseStream() {
     assertEquals(Stream.single(nil()), nil().traverseStream(constant(Stream.nil())));
     assertEquals(Stream.nil(), single("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.single(nil()), nil().traverseStream(constant(Stream.single(0))));
@@ -311,13 +321,13 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseTrampoline() {
+  void testTraverseTrampoline() {
     assertEquals(Trampoline.pure(nil()).run(), nil().traverseTrampoline(constant(Trampoline.pure(0))).run());
     assertEquals(Trampoline.pure(single(0)).run(), single("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testTraverseValidation() {
+  void testTraverseValidation() {
     assertEquals(success(nil()), nil().traverseValidation(constant(fail(single(0)))));
     assertEquals(fail(single(0)), single("zero").traverseValidation(constant(fail(single(0)))));
     assertEquals(success(nil()), nil().traverseValidation(constant(success(0))));
@@ -328,7 +338,7 @@ public class StreamTest {
   }
 
   @Test
-  public void testTraverseValidationSemigroup() {
+  void testTraverseValidationSemigroup() {
     assertEquals(success(nil()), nil().traverseValidation(listSemigroup(), constant(fail(List.single(0)))));
     assertEquals(fail(List.single(0)), single("zero").traverseValidation(listSemigroup(), constant(fail(List.single(0)))));
     assertEquals(success(nil()), nil().traverseValidation(listSemigroup(), constant(success(0))));

--- a/core/src/test/java/fj/data/TreeMapTest.java
+++ b/core/src/test/java/fj/data/TreeMapTest.java
@@ -8,113 +8,113 @@ import fj.P3;
 import fj.Show;
 import fj.P2;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.P.p;
 import static fj.data.Option.none;
 import static fj.data.Option.some;
 import static fj.data.TreeMap.iterableTreeMap;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class TreeMapTest {
 
-    @Test
-    public void split() {
-        // do the split
-        int pivot = 4;
-        int max = 5;
-        List<Integer> l = List.range(1, max + 1);
-        TreeMap<Integer, String> m2 = iterableTreeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
-        P3<Set<String>, Option<String>, Set<String>> p = m2.split(Ord.stringOrd, pivot);
+  @Test
+  void split() {
+    // do the split
+    int pivot = 4;
+    int max = 5;
+    List<Integer> l = List.range(1, max + 1);
+    TreeMap<Integer, String> m2 = iterableTreeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+    P3<Set<String>, Option<String>, Set<String>> p = m2.split(Ord.stringOrd, pivot);
 
-        // print debug info
-        Show<TreeMap<Integer, String>> st = Show.treeMapShow(Show.intShow, Show.stringShow);
-        Show<Set<String>> ss = Show.setShow(Show.stringShow);
-        Show<Option<String>> so = Show.optionShow(Show.stringShow);
-        Show<P3<Set<String>, Option<String>, Set<String>>> sp3 = Show.p3Show(ss, so, ss);
+    // print debug info
+    Show<TreeMap<Integer, String>> st = Show.treeMapShow(Show.intShow, Show.stringShow);
+    Show<Set<String>> ss = Show.setShow(Show.stringShow);
+    Show<Option<String>> so = Show.optionShow(Show.stringShow);
+    Show<P3<Set<String>, Option<String>, Set<String>>> sp3 = Show.p3Show(ss, so, ss);
 
-        // assert equals
-        Equal<Set<String>> seq = Equal.setEqual(Equal.stringEqual);
-        Set<String> left = toSetString(List.range(1, pivot));
-        Set<String> right = toSetString(List.range(pivot + 1, max + 1));
-        P3<Set<String>, Option<String>, Set<String>> expected = p(left, some(Integer.toString(pivot)), right);
-        assertTrue(Equal.p3Equal(seq, Equal.optionEqual(Equal.stringEqual), seq).eq(p, expected));
+    // assert equals
+    Equal<Set<String>> seq = Equal.setEqual(Equal.stringEqual);
+    Set<String> left = toSetString(List.range(1, pivot));
+    Set<String> right = toSetString(List.range(pivot + 1, max + 1));
+    P3<Set<String>, Option<String>, Set<String>> expected = p(left, some(Integer.toString(pivot)), right);
+    assertTrue(Equal.p3Equal(seq, Equal.optionEqual(Equal.stringEqual), seq).eq(p, expected));
+  }
+
+  private static Set<String> toSetString(List<Integer> list) {
+    return Set.iterableSet(Ord.stringOrd, list.map(i -> i.toString()));
+  }
+
+  @Test
+  void splitLookup() {
+    // do the split
+    int pivot = 4;
+    int max = 5;
+    List<Integer> l = List.range(1, max + 1);
+    TreeMap<Integer, String> m2 = iterableTreeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
+    P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>> p3 = m2.splitLookup(pivot);
+
+    // create expected output
+    List<Integer> leftList = List.range(1, pivot);
+    TreeMap<Integer, String> leftMap = iterableTreeMap(Ord.intOrd, leftList.zip(leftList.map(i -> i.toString())));
+    List<Integer> rightList = List.range(pivot + 1, max + 1);
+    TreeMap<Integer, String> rightMap = iterableTreeMap(Ord.intOrd, rightList.zip(rightList.map(i -> i.toString())));
+
+    // do the assert
+    Equal<TreeMap<Integer, String>> tme = Equal.treeMapEqual(Equal.intEqual, Equal.stringEqual);
+    Equal<P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>>> eq = Equal.p3Equal(tme, Equal.optionEqual(Equal.stringEqual), tme);
+    assertTrue(eq.eq(p3, p(leftMap, some(Integer.toString(pivot)), rightMap)));
+  }
+
+  @Test
+  void toMutableMap() {
+    int max = 5;
+    List<List<Integer>> l = List.range(1, max + 1).map(n -> List.single(n));
+    TreeMap<List<Integer>, String> m2 = iterableTreeMap(Ord.listOrd(Ord.intOrd), l.zip(l.map(i -> i.toString())));
+    Map<List<Integer>, String> mm = m2.toMutableMap();
+    assertEquals(m2.keys(), List.iterableList(mm.keySet()));
+  }
+
+
+  @Test
+  void testLargeInserts() {
+    // check that inserting a large number of items performs ok
+    // taken from https://code.google.com/p/functionaljava/issues/detail?id=31 and
+    // https://github.com/functionaljava/functionaljava/pull/13/files
+    final int n = 10000;
+    TreeMap<Integer, String> m = TreeMap.empty(Ord.intOrd);
+    for (int i = 0; i < n; i++) {
+      m = m.set(i, "abc " + i);
     }
+  }
 
-    private static Set<String> toSetString(List<Integer> list) {
-        return Set.iterableSet(Ord.stringOrd, list.map(i -> i.toString()));
-    }
+  @Test
+  void testString() {
+    TreeMap<Integer, String> t = TreeMap.treeMap(Ord.intOrd, p(1, "a"), p(2, "b"), p(3, "c"));
+    TreeMap<Integer, String> t2 = TreeMap.treeMap(Ord.intOrd, p(3, "c"), p(2, "b"), p(1, "a"));
+    Stream<P2<Integer, String>> s = Stream.stream(p(1, "a"), p(2, "b"), p(3, "c"));
+    assertThat(t.toStream(), equalTo(s));
+    assertThat(t2.toStream(), equalTo(s));
+  }
 
-    @Test
-    public void splitLookup() {
-        // do the split
-        int pivot = 4;
-        int max = 5;
-        List<Integer> l = List.range(1, max + 1);
-        TreeMap<Integer, String> m2 = iterableTreeMap(Ord.intOrd, l.zip(l.map(i -> i.toString())));
-        P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>> p3 = m2.splitLookup(pivot);
+  @Test
+  void minKey() {
+    TreeMap<Integer, Integer> t1 = TreeMap.<Integer, Integer>empty(Ord.intOrd);
+    assertThat(t1.minKey(), equalTo(none()));
+    TreeMap<Integer, Integer> t2 = t1.set(1, 2).set(2, 4).set(10, 20).set(5, 10).set(0, 100);
+    assertThat(t2.minKey(), equalTo(some(0)));
+    assertThat(t2.delete(0).minKey(), equalTo(some(1)));
+  }
 
-        // create expected output
-        List<Integer> leftList = List.range(1, pivot);
-        TreeMap<Integer, String> leftMap = iterableTreeMap(Ord.intOrd, leftList.zip(leftList.map(i -> i.toString())));
-        List<Integer> rightList = List.range(pivot + 1, max + 1);
-        TreeMap<Integer, String> rightMap = iterableTreeMap(Ord.intOrd, rightList.zip(rightList.map(i -> i.toString())));
-
-        // do the assert
-        Equal<TreeMap<Integer, String>> tme = Equal.treeMapEqual(Equal.intEqual, Equal.stringEqual);
-        Equal<P3<TreeMap<Integer, String>, Option<String>, TreeMap<Integer, String>>> eq = Equal.p3Equal(tme, Equal.optionEqual(Equal.stringEqual), tme);
-        assertTrue(eq.eq(p3, p(leftMap, some(Integer.toString(pivot)), rightMap)));
-    }
-
-    @Test
-    public void toMutableMap() {
-        int max = 5;
-        List<List<Integer>> l = List.range(1, max + 1).map(n -> List.single(n));
-        TreeMap<List<Integer>, String> m2 = iterableTreeMap(Ord.listOrd(Ord.intOrd), l.zip(l.map(i -> i.toString())));
-        Map<List<Integer>, String> mm = m2.toMutableMap();
-        assertEquals(m2.keys(), List.iterableList(mm.keySet()));
-    }
-
-
-	@Test
-	public void testLargeInserts() {
-		// check that inserting a large number of items performs ok
-		// taken from https://code.google.com/p/functionaljava/issues/detail?id=31 and
-		// https://github.com/functionaljava/functionaljava/pull/13/files
-		final int n = 10000;
-		TreeMap<Integer, String> m = TreeMap.empty(Ord.intOrd);
-		for (int i = 0; i < n; i++) {
-			m = m.set(i, "abc " + i);
-		}
-	}
-
-	@Test
-	public void testString() {
-		TreeMap<Integer, String> t = TreeMap.treeMap(Ord.intOrd, p(1, "a"), p(2, "b"), p(3, "c"));
-		TreeMap<Integer, String> t2 = TreeMap.treeMap(Ord.intOrd, p(3, "c"), p(2, "b"), p(1, "a"));
-		Stream<P2<Integer, String>> s = Stream.stream(p(1, "a"), p(2, "b"), p(3, "c"));
-		assertThat(t.toStream(), equalTo(s));
-		assertThat(t2.toStream(), equalTo(s));
-	}
-
-    @Test
-    public void minKey() {
-        TreeMap<Integer, Integer> t1 = TreeMap.<Integer, Integer>empty(Ord.intOrd);
-        assertThat(t1.minKey(), equalTo(none()));
-        TreeMap<Integer, Integer> t2 = t1.set(1, 2).set(2, 4).set(10, 20).set(5, 10).set(0, 100);
-        assertThat(t2.minKey(), equalTo(some(0)));
-        assertThat(t2.delete(0).minKey(), equalTo(some(1)));
-    }
-
-    @Test
-    public void emptyHashCode() {
-        // Hash code of tree map should not throw NullPointerException
-        // see https://github.com/functionaljava/functionaljava/issues/187
-        int i = TreeMap.empty(Ord.stringOrd).hashCode();
-        assertTrue(true);
-    }
+  @Test
+  void emptyHashCode() {
+    // Hash code of tree map should not throw NullPointerException
+    // see https://github.com/functionaljava/functionaljava/issues/187
+    int i = TreeMap.empty(Ord.stringOrd).hashCode();
+    assertTrue(true);
+  }
 
 }

--- a/core/src/test/java/fj/data/TreeTest.java
+++ b/core/src/test/java/fj/data/TreeTest.java
@@ -1,6 +1,6 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Tree.leaf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -8,41 +8,41 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TreeTest {
 
-    @Test
-    public void emptyLength() {
-        Tree<Integer> t = leaf(1);
-        assertThat(t.length(), equalTo(1));
-    }
+  @Test
+  void emptyLength() {
+    Tree<Integer> t = leaf(1);
+    assertThat(t.length(), equalTo(1));
+  }
 
-    @Test
-    public void shallowStreamLength() {
-        Tree<Integer> t2 = Tree.node(3, Stream.stream(leaf(4), leaf(5)));
-        assertThat(t2.length(), equalTo(3));
-    }
+  @Test
+  void shallowStreamLength() {
+    Tree<Integer> t2 = Tree.node(3, Stream.stream(leaf(4), leaf(5)));
+    assertThat(t2.length(), equalTo(3));
+  }
 
-    @Test
-    public void deepStreamLength() {
-        Tree<Integer> t3 = Tree.node(4, Stream.stream(leaf(5), Tree.node(6, Stream.stream(leaf(7), leaf(8)))));
-        assertThat(t3.length(), equalTo(5));
-    }
+  @Test
+  void deepStreamLength() {
+    Tree<Integer> t3 = Tree.node(4, Stream.stream(leaf(5), Tree.node(6, Stream.stream(leaf(7), leaf(8)))));
+    assertThat(t3.length(), equalTo(5));
+  }
 
 
-    @Test
-    public void singleIsLeft() {
-        Tree<Integer> t = leaf(1);
-        assertThat(t.isLeaf(), equalTo(true));
-    }
+  @Test
+  void singleIsLeft() {
+    Tree<Integer> t = leaf(1);
+    assertThat(t.isLeaf(), equalTo(true));
+  }
 
-    @Test
-    public void shallowStreamIsLeaf() {
-        Tree<Integer> t2 = Tree.node(3, Stream.stream(leaf(4), leaf(5)));
-        assertThat(t2.isLeaf(), equalTo(false));
-    }
+  @Test
+  void shallowStreamIsLeaf() {
+    Tree<Integer> t2 = Tree.node(3, Stream.stream(leaf(4), leaf(5)));
+    assertThat(t2.isLeaf(), equalTo(false));
+  }
 
-    @Test
-    public void deepStreamIsLeaf() {
-        Tree<Integer> t3 = Tree.node(4, Stream.stream(leaf(5), Tree.node(6, Stream.stream(leaf(7), leaf(8)))));
-        assertThat(t3.isLeaf(), equalTo(false));
-    }
+  @Test
+  void deepStreamIsLeaf() {
+    Tree<Integer> t3 = Tree.node(4, Stream.stream(leaf(5), Tree.node(6, Stream.stream(leaf(7), leaf(8)))));
+    assertThat(t3.isLeaf(), equalTo(false));
+  }
 
 }

--- a/core/src/test/java/fj/data/TreeZipperTest.java
+++ b/core/src/test/java/fj/data/TreeZipperTest.java
@@ -1,32 +1,32 @@
 package fj.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Option.none;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TreeZipperTest {
-    @Test
-    public void testDelete() {
-        final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
-        final TreeZipper<Integer> tz = TreeZipper.fromTree(t);
-        assertThat(tz.delete(), is(none()));
-    }
+  @Test
+  void testDelete() {
+    final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
+    final TreeZipper<Integer> tz = TreeZipper.fromTree(t);
+    assertThat(tz.delete(), is(none()));
+  }
 
-    @Test
-    public void testDeleteForest() {
-        final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
-        final TreeZipper<Integer> tz = TreeZipper.fromForest(Stream.single(t)).some();
-        assertThat(tz.delete(), is(none()));
+  @Test
+  void testDeleteForest() {
+    final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
+    final TreeZipper<Integer> tz = TreeZipper.fromForest(Stream.single(t)).some();
+    assertThat(tz.delete(), is(none()));
 
-    }
+  }
 
-    @Test
-    public void testHash() {
-        final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
-        final TreeZipper<Integer> tz1 = TreeZipper.fromForest(Stream.single(t)).some();
-        final TreeZipper<Integer> tz2 = TreeZipper.fromForest(Stream.single(t)).some();
-        assertThat(tz1.hashCode(), is(tz2.hashCode()));
-    }
+  @Test
+  void testHash() {
+    final Tree<Integer> t = Tree.node(1, List.single(Tree.leaf(2)));
+    final TreeZipper<Integer> tz1 = TreeZipper.fromForest(Stream.single(t)).some();
+    final TreeZipper<Integer> tz2 = TreeZipper.fromForest(Stream.single(t)).some();
+    assertThat(tz1.hashCode(), is(tz2.hashCode()));
+  }
 }

--- a/core/src/test/java/fj/data/UnitTest.java
+++ b/core/src/test/java/fj/data/UnitTest.java
@@ -1,16 +1,16 @@
 package fj.data;
 
 import fj.Unit;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UnitTest {
 
-    @Test
-    public void objectMethods() {
-        Assert.assertTrue(Unit.unit().equals(Unit.unit()));
-        Assert.assertFalse(Unit.unit().equals(3));
-        Assert.assertTrue(Unit.unit().toString().equals("unit"));
-    }
+  @Test
+  void objectMethods() {
+    Assertions.assertTrue(Unit.unit().equals(Unit.unit()));
+    Assertions.assertFalse(Unit.unit().equals(3));
+    Assertions.assertTrue(Unit.unit().toString().equals("unit"));
+  }
 
 }

--- a/core/src/test/java/fj/data/ValidationTest.java
+++ b/core/src/test/java/fj/data/ValidationTest.java
@@ -4,9 +4,10 @@ import fj.P;
 import fj.P2;
 import fj.Semigroup;
 import fj.control.Trampoline;
-import org.junit.Test;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Function.*;
 import static fj.Ord.*;
@@ -36,320 +37,325 @@ import static fj.data.Validation.sequenceTrampoline;
 import static fj.data.Validation.sequenceValidation;
 import static fj.data.Validation.*;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class ValidationTest {
-    @Test
-    public void testParseShort() {
-        final List<Validation<NumberFormatException, Short>> l =
-                List.list(parseShort("10"), parseShort("x"), parseShort("20"));
-        assertThat(successes(l).foldLeft1((s, a) -> (short)(s + a)), is((short)30));
-    }
-
-    @Test
-    public void testParseLong() {
-        final List<Validation<NumberFormatException, Long>> l =
-                List.list(parseLong("10"), parseLong("x"), parseLong("20"));
-        P2<List<NumberFormatException>, List<Long>> p2 = partition(l);
-        assertThat(p2._1().length(), is(1));
-        assertThat(p2._2().length(), is(2));
-    }
-
-    @Test
-    public void testParseInt() {
-        final List<Validation<NumberFormatException, Integer>> l =
-                List.list(parseInt("10"), parseInt("x"), parseInt("20"));
-        assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
-                is(2));
-    }
-
-    @Test
-    public void testParseFloat() {
-        final List<Validation<NumberFormatException, Float>> l =
-                List.list(parseFloat("2.0"), parseFloat("x"), parseFloat("3.0"));
-        assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
-                is(2));
-    }
-
-    @Test
-    public void testParseByte() {
-        final List<Validation<NumberFormatException, Byte>> l =
-                List.list(parseByte("10"), parseByte("x"), parseByte("-10"));
-        assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
-                is(2));
-    }
-
-    @Test
-    public void testAccumulate1() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("10.0").accumulate(
-                        f1 -> f1);
-        assertThat(v.success(), is(10.0));
-    }
-
-    @Test
-    public void testAccumulate1Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        f1 -> f1);
-        assertThat(v.fail().length(), is(1));
-    }
-
-    @Test
-    public void testAccumulate2() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        (f1, f2) -> f1 + f2);
-        assertThat(v.success(), is(3.0));
-    }
-
-    @Test
-    public void testAccumulate2Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("y"),
-                        (f1, f2) -> f1 + f2);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate3() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        (f1, f2, f3) -> f1 + f2 + f3);
-        assertThat(v.success(), is(6.0));
-    }
-
-    @Test
-    public void testAccumulate3Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3) -> f1 + f2 + f3);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate4() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        (f1, f2, f3, f4) -> f1 + f2 + f3 + f4);
-        assertThat(v.success(), is(10.0));
-    }
-
-    @Test
-    public void testAccumulate4Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3, f4) -> f1 + f2 + f3 + f4);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate5() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        (f1, f2, f3, f4, f5) -> f1 + f2 + f3 + f4 + f5);
-        assertThat(v.success(), is(15.0));
-    }
-
-    @Test
-    public void testAccumulate5Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3, f4, f5) -> f1 + f2 + f3 + f4 + f5);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate6() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("6.0"),
-                        (f1, f2, f3, f4, f5, f6) -> f1 + f2 + f3 + f4 + f5 + f6);
-        assertThat(v.success(), is(21.0));
-    }
-
-    @Test
-    public void testAccumulate6Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3, f4, f5, f6) -> f1 + f2 + f3 + f4 + f5 + f6);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate7() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("6.0"),
-                        parseDouble("7.0"),
-                        (f1, f2, f3, f4, f5, f6, f7) -> f1 + f2 + f3 + f4 + f5 + f6 + f7);
-        assertThat(v.success(), is(28.0));
-    }
-
-    @Test
-    public void testAccumulate7Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("6.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3, f4, f5, f6, f7) -> f1 + f2 + f3 + f4 + f5 + f6 + f7);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate8() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("1.0").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("6.0"),
-                        parseDouble("7.0"),
-                        parseDouble("8.0"),
-                        (f1, f2, f3, f4, f5, f6, f7, f8) -> f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8);
-        assertThat(v.success(), is(36.0));
-    }
-
-    @Test
-    public void testAccumulate8Fail() {
-        final Validation<List<NumberFormatException>, Double> v =
-                parseDouble("x").accumulate(
-                        parseDouble("2.0"),
-                        parseDouble("3.0"),
-                        parseDouble("4.0"),
-                        parseDouble("5.0"),
-                        parseDouble("6.0"),
-                        parseDouble("7.0"),
-                        parseDouble("y"),
-                        (f1, f2, f3, f4, f5, f6, f7, f8) -> f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8);
-        assertThat(v.fail().length(), is(2));
-    }
-
-    @Test
-    public void testAccumulate8s() {
-        final Validation<NumberFormatException, Integer> v1 = parseInt("1");
-        final Validation<NumberFormatException, Integer> v2 = parseInt("2");
-        final Validation<NumberFormatException, Integer> v3 = parseInt("3");
-        final Validation<NumberFormatException, Integer> v4 = parseInt("4");
-        final Validation<NumberFormatException, Integer> v5 = parseInt("5");
-        final Validation<NumberFormatException, Integer> v6 = parseInt("6");
-        final Validation<NumberFormatException, Integer> v7 = parseInt("7");
-        final Validation<NumberFormatException, Integer> v8 = parseInt("8");
-        final Option<NumberFormatException> on2 = v1.accumulate(firstSemigroup(), v2);
-        assertThat(on2, is(Option.none()));
-        final Option<NumberFormatException> on3 = v1.accumulate(firstSemigroup(), v2, v3);
-        assertThat(on3, is(Option.none()));
-        final Option<NumberFormatException> on4 = v1.accumulate(firstSemigroup(), v2, v3, v4);
-        assertThat(on4, is(Option.none()));
-        final Option<NumberFormatException> on5 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5);
-        assertThat(on5, is(Option.none()));
-        final Option<NumberFormatException> on6 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6);
-        assertThat(on6, is(Option.none()));
-        final Option<NumberFormatException> on7 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6, v7);
-        assertThat(on7, is(Option.none()));
-        final Option<NumberFormatException> on8 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6, v7, v8);
-        assertThat(on8, is(Option.none()));
-    }
-
-    @Test
-    public void testAccumulate8sFail() {
-        final Option<NumberFormatException> on =
-                parseInt("x").accumulate(
-                        firstSemigroup(),
-                        parseInt("2"),
-                        parseInt("3"),
-                        parseInt("4"),
-                        parseInt("5"),
-                        parseInt("6"),
-                        parseInt("7"),
-                        parseInt("y"));
-        assertThat(on.some().getMessage(), is("For input string: \"x\""));
-    }
-
-    @Test(expected = Error.class)
-    public void testSuccess() {
-        parseShort("x").success();
-    }
-
-    @Test(expected = Error.class)
-    public void testFail() {
-        parseShort("12").fail();
-    }
-
-    @Test
-    public void testCondition() {
-        final Validation<String, String> one = condition(true, "not 1", "one");
-        assertThat(one.success(), is("one"));
-        final Validation<String, String> fail = condition(false, "not 1", "one");
-        assertThat(fail.fail(), is("not 1"));
-    }
-
-    @Test
-    public void testNel() {
-        assertThat(Validation.success("success").nel().success(), is("success"));
-        assertThat(Validation.fail("fail").nel().fail().head(), is("fail"));
-    }
-
-    @Test
-    public void testFailNEL() {
-        Validation<NonEmptyList<Exception>, Integer> v = failNEL(new Exception("failed"));
-        assertThat(v.isFail(), is(true));
-    }
-
-    @Test
-    public void testEither() {
-        assertThat(either().f(Validation.success("success")).right().value(), is("success"));
-        assertThat(either().f(Validation.fail("fail")).left().value(), is("fail"));
-    }
-
-    @Test
-    public void testValidation() {
-        assertThat(validation().f(Either.right("success")).success(), is("success"));
-        assertThat(validation().f(Either.left("fail")).fail(), is("fail"));
-    }
+  @Test
+  void testParseShort() {
+    final List<Validation<NumberFormatException, Short>> l =
+        List.list(parseShort("10"), parseShort("x"), parseShort("20"));
+    assertThat(successes(l).foldLeft1((s, a) -> (short) (s + a)), is((short) 30));
+  }
 
   @Test
-  public void testAccumulateSemigroup2() {
+  void testParseLong() {
+    final List<Validation<NumberFormatException, Long>> l =
+        List.list(parseLong("10"), parseLong("x"), parseLong("20"));
+    P2<List<NumberFormatException>, List<Long>> p2 = partition(l);
+    assertThat(p2._1().length(), is(1));
+    assertThat(p2._2().length(), is(2));
+  }
+
+  @Test
+  void testParseInt() {
+    final List<Validation<NumberFormatException, Integer>> l =
+        List.list(parseInt("10"), parseInt("x"), parseInt("20"));
+    assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
+        is(2));
+  }
+
+  @Test
+  void testParseFloat() {
+    final List<Validation<NumberFormatException, Float>> l =
+        List.list(parseFloat("2.0"), parseFloat("x"), parseFloat("3.0"));
+    assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
+        is(2));
+  }
+
+  @Test
+  void testParseByte() {
+    final List<Validation<NumberFormatException, Byte>> l =
+        List.list(parseByte("10"), parseByte("x"), parseByte("-10"));
+    assertThat(l.map(v -> v.validation(e -> 0, i -> 1)).foldLeft1((s, a) -> s + a),
+        is(2));
+  }
+
+  @Test
+  void testAccumulate1() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("10.0").accumulate(
+            f1 -> f1);
+    assertThat(v.success(), is(10.0));
+  }
+
+  @Test
+  void testAccumulate1Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            f1 -> f1);
+    assertThat(v.fail().length(), is(1));
+  }
+
+  @Test
+  void testAccumulate2() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            (f1, f2) -> f1 + f2);
+    assertThat(v.success(), is(3.0));
+  }
+
+  @Test
+  void testAccumulate2Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("y"),
+            (f1, f2) -> f1 + f2);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate3() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            (f1, f2, f3) -> f1 + f2 + f3);
+    assertThat(v.success(), is(6.0));
+  }
+
+  @Test
+  void testAccumulate3Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("y"),
+            (f1, f2, f3) -> f1 + f2 + f3);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate4() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            (f1, f2, f3, f4) -> f1 + f2 + f3 + f4);
+    assertThat(v.success(), is(10.0));
+  }
+
+  @Test
+  void testAccumulate4Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("y"),
+            (f1, f2, f3, f4) -> f1 + f2 + f3 + f4);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate5() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            (f1, f2, f3, f4, f5) -> f1 + f2 + f3 + f4 + f5);
+    assertThat(v.success(), is(15.0));
+  }
+
+  @Test
+  void testAccumulate5Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("y"),
+            (f1, f2, f3, f4, f5) -> f1 + f2 + f3 + f4 + f5);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate6() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("6.0"),
+            (f1, f2, f3, f4, f5, f6) -> f1 + f2 + f3 + f4 + f5 + f6);
+    assertThat(v.success(), is(21.0));
+  }
+
+  @Test
+  void testAccumulate6Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("y"),
+            (f1, f2, f3, f4, f5, f6) -> f1 + f2 + f3 + f4 + f5 + f6);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate7() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("6.0"),
+            parseDouble("7.0"),
+            (f1, f2, f3, f4, f5, f6, f7) -> f1 + f2 + f3 + f4 + f5 + f6 + f7);
+    assertThat(v.success(), is(28.0));
+  }
+
+  @Test
+  void testAccumulate7Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("6.0"),
+            parseDouble("y"),
+            (f1, f2, f3, f4, f5, f6, f7) -> f1 + f2 + f3 + f4 + f5 + f6 + f7);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate8() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("1.0").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("6.0"),
+            parseDouble("7.0"),
+            parseDouble("8.0"),
+            (f1, f2, f3, f4, f5, f6, f7, f8) -> f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8);
+    assertThat(v.success(), is(36.0));
+  }
+
+  @Test
+  void testAccumulate8Fail() {
+    final Validation<List<NumberFormatException>, Double> v =
+        parseDouble("x").accumulate(
+            parseDouble("2.0"),
+            parseDouble("3.0"),
+            parseDouble("4.0"),
+            parseDouble("5.0"),
+            parseDouble("6.0"),
+            parseDouble("7.0"),
+            parseDouble("y"),
+            (f1, f2, f3, f4, f5, f6, f7, f8) -> f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8);
+    assertThat(v.fail().length(), is(2));
+  }
+
+  @Test
+  void testAccumulate8s() {
+    final Validation<NumberFormatException, Integer> v1 = parseInt("1");
+    final Validation<NumberFormatException, Integer> v2 = parseInt("2");
+    final Validation<NumberFormatException, Integer> v3 = parseInt("3");
+    final Validation<NumberFormatException, Integer> v4 = parseInt("4");
+    final Validation<NumberFormatException, Integer> v5 = parseInt("5");
+    final Validation<NumberFormatException, Integer> v6 = parseInt("6");
+    final Validation<NumberFormatException, Integer> v7 = parseInt("7");
+    final Validation<NumberFormatException, Integer> v8 = parseInt("8");
+    final Option<NumberFormatException> on2 = v1.accumulate(firstSemigroup(), v2);
+    assertThat(on2, is(Option.none()));
+    final Option<NumberFormatException> on3 = v1.accumulate(firstSemigroup(), v2, v3);
+    assertThat(on3, is(Option.none()));
+    final Option<NumberFormatException> on4 = v1.accumulate(firstSemigroup(), v2, v3, v4);
+    assertThat(on4, is(Option.none()));
+    final Option<NumberFormatException> on5 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5);
+    assertThat(on5, is(Option.none()));
+    final Option<NumberFormatException> on6 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6);
+    assertThat(on6, is(Option.none()));
+    final Option<NumberFormatException> on7 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6, v7);
+    assertThat(on7, is(Option.none()));
+    final Option<NumberFormatException> on8 = v1.accumulate(firstSemigroup(), v2, v3, v4, v5, v6, v7, v8);
+    assertThat(on8, is(Option.none()));
+  }
+
+  @Test
+  void testAccumulate8sFail() {
+    final Option<NumberFormatException> on =
+        parseInt("x").accumulate(
+            firstSemigroup(),
+            parseInt("2"),
+            parseInt("3"),
+            parseInt("4"),
+            parseInt("5"),
+            parseInt("6"),
+            parseInt("7"),
+            parseInt("y"));
+    assertThat(on.some().getMessage(), is("For input string: \"x\""));
+  }
+
+  @Test
+  void testSuccess() {
+    assertThrows(Error.class, () -> {
+      parseShort("x").success();
+    });
+  }
+
+  @Test
+  void testFail() {
+    assertThrows(Error.class, () -> {
+      parseShort("12").fail();
+    });
+  }
+
+  @Test
+  void testCondition() {
+    final Validation<String, String> one = condition(true, "not 1", "one");
+    assertThat(one.success(), is("one"));
+    final Validation<String, String> fail = condition(false, "not 1", "one");
+    assertThat(fail.fail(), is("not 1"));
+  }
+
+  @Test
+  void testNel() {
+    assertThat(Validation.success("success").nel().success(), is("success"));
+    assertThat(Validation.fail("fail").nel().fail().head(), is("fail"));
+  }
+
+  @Test
+  void testFailNEL() {
+    Validation<NonEmptyList<Exception>, Integer> v = failNEL(new Exception("failed"));
+    assertThat(v.isFail(), is(true));
+  }
+
+  @Test
+  void testEither() {
+    assertThat(either().f(Validation.success("success")).right().value(), is("success"));
+    assertThat(either().f(Validation.fail("fail")).left().value(), is("fail"));
+  }
+
+  @Test
+  void testValidation() {
+    assertThat(validation().f(Either.right("success")).success(), is("success"));
+    assertThat(validation().f(Either.left("fail")).fail(), is("fail"));
+  }
+
+  @Test
+  void testAccumulateSemigroup2() {
     range(0, 2).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -362,93 +368,93 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulateSemigroup3() {
+  void testAccumulateSemigroup3() {
     range(0, 3).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), p3()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), uncurryF3(p3())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), p3()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), uncurryF3(p3())));
         });
 
   }
 
   @Test
-  public void testAccumulateSemigroup4() {
+  void testAccumulateSemigroup4() {
     range(0, 4).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), p4()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), uncurryF4(p4())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), p4()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), uncurryF4(p4())));
         });
 
   }
 
   @Test
-  public void testAccumulateSemigroup5() {
+  void testAccumulateSemigroup5() {
     range(0, 5).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), p5()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), uncurryF5(p5())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), p5()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), uncurryF5(p5())));
         });
   }
 
   @Test
-  public void testAccumulateSemigroup6() {
+  void testAccumulateSemigroup6() {
     range(0, 6).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), p6()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), uncurryF6(p6())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), p6()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), uncurryF6(p6())));
         });
   }
 
   @Test
-  public void testAccumulateSemigroup7() {
+  void testAccumulateSemigroup7() {
     range(0, 7).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
-        .foldLeft(accumulator -> list -> 
+        .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), p7()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), uncurryF7(p7())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), p7()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), uncurryF7(p7())));
         });
   }
 
   @Test
-  public void testAccumulateSemigroup8() {
+  void testAccumulateSemigroup8() {
     range(0, 8).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list ->
             accumulator.isEmpty() ?
-            list.map(List::single) :
-            accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
+                list.map(List::single) :
+                accumulator.bind(accumulatorElement -> list.map(accumulatorElement::snoc)), List.<List<Validation<List<String>, Integer>>>nil())
         .foreachDoEffect(list -> {
-          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7)));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6, 7)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7), P.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>p8()));
-          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6, 7)), list.index(0).accumulate(Semigroup.listSemigroup(),list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7), uncurryF8(P.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>p8())));
+          assertEquals(iif(list.exists(Validation::isFail), list.filter(Validation::isFail).bind(validation -> validation.fail())), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7)));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6, 7)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7), P.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>p8()));
+          assertEquals(condition(list.forall(Validation::isSuccess), list.filter(Validation::isFail).bind(validation -> validation.fail()), p(0, 1, 2, 3, 4, 5, 6, 7)), list.index(0).accumulate(Semigroup.listSemigroup(), list.index(1), list.index(2), list.index(3), list.index(4), list.index(5), list.index(6), list.index(7), uncurryF8(P.<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>p8())));
         });
   }
 
   @Test
-  public void testAccumulate0() {
+  void testAccumulate0() {
     range(0, 1).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -459,7 +465,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate1Complex() {
+  void testAccumulate1Complex() {
     range(0, 1).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -471,7 +477,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate2Complex() {
+  void testAccumulate2Complex() {
     range(0, 2).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -482,7 +488,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate3Complex() {
+  void testAccumulate3Complex() {
     range(0, 3).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -494,7 +500,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate4Complex() {
+  void testAccumulate4Complex() {
     range(0, 4).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -506,7 +512,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate5Complex() {
+  void testAccumulate5Complex() {
     range(0, 5).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -517,7 +523,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate6Complex() {
+  void testAccumulate6Complex() {
     range(0, 6).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -528,7 +534,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate7Complex() {
+  void testAccumulate7Complex() {
     range(0, 7).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -539,7 +545,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testAccumulate8Complex() {
+  void testAccumulate8Complex() {
     range(0, 8).map(i -> List.<Validation<List<String>, Integer>>arrayList(fail(arrayList(String.valueOf(i))), success(i)))
         .foldLeft(accumulator -> list -> accumulator.isEmpty() ?
             list.map(List::single) :
@@ -550,7 +556,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testMap() {
+  void testMap() {
     assertEquals(Validation.<String, Integer>fail("zero"), Validation.<String, String>fail("zero").map(constant(0)));
     assertEquals(Validation.<String, Integer>success(0), Validation.<String, String>success("zero").map(constant(0)));
     assertEquals(Validation.<String, Integer>fail("zero"), Validation.<String, String>fail("zero").map(constant(0)));
@@ -558,7 +564,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testBind() {
+  void testBind() {
     assertEquals(Validation.<String, Integer>fail("zero"), Validation.<String, String>fail("zero").bind(constant(Validation.<String, Integer>fail("zero"))));
     assertEquals(Validation.<String, Integer>fail("zero"), Validation.<String, String>success("zero").bind(constant(Validation.<String, Integer>fail("zero"))));
     assertEquals(Validation.<String, Integer>fail("zero"), Validation.<String, String>fail("zero").bind(constant(Validation.<String, Integer>success(0))));
@@ -566,33 +572,33 @@ public class ValidationTest {
   }
 
   @Test
-  public void testSequenceEitherLeft() {
+  void testSequenceEitherLeft() {
     assertEquals(left(fail("zero")), sequenceEitherLeft(fail("zero")));
     assertEquals(left(success("zero")), sequenceEitherLeft(success(left("zero"))));
     assertEquals(right("zero"), sequenceEitherLeft(success(right("zero"))));
   }
 
   @Test
-  public void testSequenceEitherRight() {
+  void testSequenceEitherRight() {
     assertEquals(right(fail("zero")), sequenceEitherRight(fail("zero")));
     assertEquals(right(success("zero")), sequenceEitherRight(success(right("zero"))));
     assertEquals(left("zero"), sequenceEitherRight(success(left("zero"))));
   }
 
   @Test
-  public void testSequenceF() {
+  void testSequenceF() {
     assertEquals(constant(fail("zero")).f(1), sequenceF(fail("zero")).f(1));
     assertEquals(constant(success("zero")).f(1), sequenceF(success(constant("zero"))).f(1));
   }
 
   @Test
-  public void testSequenceIO() throws IOException {
+  void testSequenceIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(fail("zero"))).run(), sequenceIO(fail("zero")).run());
     assertEquals(IOFunctions.lazy(constant(success("zero"))).run(), sequenceIO(success(IOFunctions.lazy(constant("zero")))).run());
   }
 
   @Test
-  public void testSequenceList() {
+  void testSequenceList() {
     assertEquals(single(fail("zero")), sequenceList(fail("zero")));
     assertEquals(nil(), sequenceList(success(nil())));
     assertEquals(single(success("zero")), sequenceList(success(single("zero"))));
@@ -600,20 +606,20 @@ public class ValidationTest {
   }
 
   @Test
-  public void testSequenceOption() {
+  void testSequenceOption() {
     assertEquals(some(fail("zero")), sequenceOption(fail("zero")));
     assertEquals(none(), sequenceOption(success(none())));
     assertEquals(some(success("zero")), sequenceOption(success(some("zero"))));
   }
 
   @Test
-  public void testSequenceP1() {
+  void testSequenceP1() {
     assertEquals(p(fail("zero")), sequenceP1(fail("zero")));
     assertEquals(p(success("zero")), sequenceP1(success(p("zero"))));
   }
 
   @Test
-  public void testSequenceSeq() {
+  void testSequenceSeq() {
     assertEquals(Seq.single(fail("zero")), sequenceSeq(fail("zero")));
     assertEquals(Seq.empty(), sequenceSeq(success(Seq.empty())));
     assertEquals(Seq.single(success("zero")), sequenceSeq(success(Seq.single("zero"))));
@@ -621,7 +627,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testSequenceSet() {
+  void testSequenceSet() {
     assertEquals(Set.single(validationOrd(stringOrd, intOrd), fail("zero")), sequenceSet(stringOrd, intOrd, fail("zero")));
     assertEquals(Set.empty(validationOrd(stringOrd, intOrd)), sequenceSet(stringOrd, intOrd, success(Set.empty(intOrd))));
     assertEquals(Set.single(validationOrd(intOrd, stringOrd), success("zero")), sequenceSet(intOrd, stringOrd, success(Set.single(stringOrd, "zero"))));
@@ -629,7 +635,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testSequenceStream() {
+  void testSequenceStream() {
     assertEquals(Stream.single(fail("zero")), sequenceStream(fail("zero")));
     assertEquals(Stream.nil(), sequenceStream(success(Stream.nil())));
     assertEquals(Stream.single(success("zero")), sequenceStream(success(Stream.single("zero"))));
@@ -637,20 +643,20 @@ public class ValidationTest {
   }
 
   @Test
-  public void testSequenceTrampoline() {
+  void testSequenceTrampoline() {
     assertEquals(Trampoline.pure(fail("zero")).run(), sequenceTrampoline(fail("zero")).run());
     assertEquals(Trampoline.pure(success(0)).run(), sequenceTrampoline(success(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     assertEquals(success(fail("zero")), sequenceValidation(fail("zero")));
     assertEquals(fail("zero"), sequenceValidation(success(fail("zero"))));
     assertEquals(success(success(0)), sequenceValidation(success(success(0))));
   }
 
   @Test
-  public void testTraverseEitherLeft() {
+  void testTraverseEitherLeft() {
     assertEquals(left(fail("zero")), fail("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(success(0)), success("zero").traverseEitherLeft(constant(left(0))));
     assertEquals(left(fail("zero")), fail("zero").traverseEitherLeft(constant(right(0))));
@@ -658,7 +664,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseEitherRight() {
+  void testTraverseEitherRight() {
     assertEquals(right(fail("zero")), fail("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(success(0)), success("zero").traverseEitherRight(constant(right(0))));
     assertEquals(right(fail("zero")), fail("zero").traverseEitherRight(constant(left(0))));
@@ -666,19 +672,19 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseF() {
+  void testTraverseF() {
     assertEquals(constant(fail("zero")).f(1), fail("zero").traverseF(constant(constant(0))).f(1));
     assertEquals(constant(success(0)).f(1), success("zero").traverseF(constant(constant(0))).f(1));
   }
 
   @Test
-  public void testTraverseIO() throws IOException {
+  void testTraverseIO() throws IOException {
     assertEquals(IOFunctions.lazy(constant(fail("zero"))).run(), fail("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
     assertEquals(IOFunctions.lazy(constant(success(0))).run(), success("zero").traverseIO(constant(IOFunctions.lazy(constant(0)))).run());
   }
 
   @Test
-  public void testTraverseList() {
+  void testTraverseList() {
     assertEquals(single(fail("zero")), fail("zero").traverseList(constant(nil())));
     assertEquals(nil(), success("zero").traverseList(constant(nil())));
     assertEquals(single(fail("zero")), fail("zero").traverseList(constant(single(0))));
@@ -688,7 +694,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseOption() {
+  void testTraverseOption() {
     assertEquals(some(fail("zero")), fail("zero").traverseOption(constant(none())));
     assertEquals(none(), success("zero").traverseOption(constant(none())));
     assertEquals(some(fail("zero")), fail("zero").traverseOption(constant(some(0))));
@@ -696,13 +702,13 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseP1() {
+  void testTraverseP1() {
     assertEquals(p(fail("zero")), fail("zero").traverseP1(constant(p(0))));
     assertEquals(p(success(0)), success("zero").traverseP1(constant(p(0))));
   }
 
   @Test
-  public void testTraverseSeq() {
+  void testTraverseSeq() {
     assertEquals(Seq.single(fail("zero")), fail("zero").traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.empty(), success("zero").traverseSeq(constant(Seq.empty())));
     assertEquals(Seq.single(fail("zero")), fail("zero").traverseSeq(constant(Seq.single(0))));
@@ -712,7 +718,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseSet() {
+  void testTraverseSet() {
     assertEquals(Set.single(validationOrd(stringOrd, intOrd), fail("zero")), fail("zero").traverseSet(stringOrd, intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.empty(validationOrd(stringOrd, intOrd)), Validation.<String, String>success("zero").traverseSet(stringOrd, intOrd, constant(Set.empty(intOrd))));
     assertEquals(Set.single(validationOrd(stringOrd, intOrd), fail("zero")), fail("zero").traverseSet(stringOrd, intOrd, constant(Set.single(intOrd, 0))));
@@ -722,7 +728,7 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseStream() {
+  void testTraverseStream() {
     assertEquals(Stream.single(fail("zero")), fail("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.nil(), success("zero").traverseStream(constant(Stream.nil())));
     assertEquals(Stream.single(fail("zero")), fail("zero").traverseStream(constant(Stream.single(0))));
@@ -732,13 +738,13 @@ public class ValidationTest {
   }
 
   @Test
-  public void testTraverseTrampoline() {
+  void testTraverseTrampoline() {
     assertEquals(Trampoline.pure(fail("zero")).run(), fail("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
     assertEquals(Trampoline.pure(success(0)).run(), success("zero").traverseTrampoline(constant(Trampoline.pure(0))).run());
   }
 
   @Test
-  public void testTraverseValidation() {
+  void testTraverseValidation() {
     assertEquals(Validation.<String, Validation<String, Integer>>success(fail("zero")), Validation.<String, String>fail("zero").traverseValidation(constant(Validation.<Integer, Integer>fail(0))));
     assertEquals(Validation.<Integer, Validation<String, Integer>>fail(0), Validation.<String, String>success("zero").traverseValidation(constant(Validation.<Integer, Integer>fail(0))));
     assertEquals(Validation.<String, Validation<String, Integer>>success(fail("zero")), Validation.<String, String>fail("zero").traverseValidation(constant(Validation.<Integer, Integer>success(0))));

--- a/core/src/test/java/fj/data/ZipperTest.java
+++ b/core/src/test/java/fj/data/ZipperTest.java
@@ -1,110 +1,111 @@
 package fj.data;
 
-import org.junit.Test;
-
 import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ZipperTest {
-    @Test
-    public void testZipper() {
-        Zipper<Integer> z = Zipper.zipper(Stream.nil(), 0, Stream.range(1, 9));
-        assertThat(z.map(i -> i + 13).toStream(), is(Stream.range(13, 22)));
-    }
+  @Test
+  void testZipper() {
+    Zipper<Integer> z = Zipper.zipper(Stream.nil(), 0, Stream.range(1, 9));
+    assertThat(z.map(i -> i + 13).toStream(), is(Stream.range(13, 22)));
+  }
 
-    @Test
-    public void testNext() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
-        z = z.next().some();
-        assertThat(z.lefts(), is(Stream.arrayStream(new Integer[]{2, 1})));
-        assertThat(z.focus(), is(3));
-        assertThat(z.rights(), is(Stream.nil()));
-    }
+  @Test
+  void testNext() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
+    z = z.next().some();
+    assertThat(z.lefts(), is(Stream.arrayStream(new Integer[]{2, 1})));
+    assertThat(z.focus(), is(3));
+    assertThat(z.rights(), is(Stream.nil()));
+  }
 
-    @Test
-    public void testNextNone() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.nil());
-        assertThat(z.next().isNone(), is(true));
-    }
+  @Test
+  void testNextNone() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.nil());
+    assertThat(z.next().isNone(), is(true));
+  }
 
-    @Test
-    public void testCycleNext() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
-        assertThat(z.cycleNext(), is(z.next().some()));
-    }
+  @Test
+  void testCycleNext() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
+    assertThat(z.cycleNext(), is(z.next().some()));
+  }
 
-    @Test
-    public void testCycleNextLast() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.nil());
-        z = z.cycleNext();
-        assertThat(z.lefts(), is(Stream.nil()));
-        assertThat(z.focus(), is(1));
-        assertThat(z.rights(), is(Stream.single(2)));
-    }
+  @Test
+  void testCycleNextLast() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.nil());
+    z = z.cycleNext();
+    assertThat(z.lefts(), is(Stream.nil()));
+    assertThat(z.focus(), is(1));
+    assertThat(z.rights(), is(Stream.single(2)));
+  }
 
-    @Test
-    public void testPrevious() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
-        z = z.previous().some();
-        assertThat(z.lefts(), is(Stream.nil()));
-        assertThat(z.focus(), is(1));
-        assertThat(z.rights(), is(Stream.arrayStream(new Integer[]{2, 3})));
-    }
+  @Test
+  void testPrevious() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
+    z = z.previous().some();
+    assertThat(z.lefts(), is(Stream.nil()));
+    assertThat(z.focus(), is(1));
+    assertThat(z.rights(), is(Stream.arrayStream(new Integer[]{2, 3})));
+  }
 
-    @Test
-    public void testPreviousNone() {
-        Zipper<Integer> z = Zipper.zipper(Stream.nil(), 2, Stream.single(3));
-        assertThat(z.previous().isNone(), is(true));
-    }
+  @Test
+  void testPreviousNone() {
+    Zipper<Integer> z = Zipper.zipper(Stream.nil(), 2, Stream.single(3));
+    assertThat(z.previous().isNone(), is(true));
+  }
 
-    @Test
-    public void testCyclePrevious() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
-        assertThat(z.cyclePrevious(), is(z.previous().some()));
-    }
+  @Test
+  void testCyclePrevious() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
+    assertThat(z.cyclePrevious(), is(z.previous().some()));
+  }
 
-    @Test
-    public void testCyclePreviousFirst() {
-        Zipper<Integer> z = Zipper.zipper(Stream.nil(), 1, Stream.single(2));
-        z = z.cyclePrevious();
-        assertThat(z.lefts(), is(Stream.single(1)));
-        assertThat(z.focus(), is(2));
-        assertThat(z.rights(), is(Stream.nil()));
-    }
+  @Test
+  void testCyclePreviousFirst() {
+    Zipper<Integer> z = Zipper.zipper(Stream.nil(), 1, Stream.single(2));
+    z = z.cyclePrevious();
+    assertThat(z.lefts(), is(Stream.single(1)));
+    assertThat(z.focus(), is(2));
+    assertThat(z.rights(), is(Stream.nil()));
+  }
 
-    @Test
-    public void testInsertLeft() {
-        Zipper<Integer> z = Zipper.single(2);
-        z = z.insertLeft(1);
-        assertThat(z.lefts(), is(Stream.nil()));
-        assertThat(z.focus(), is(1));
-        assertThat(z.rights(), is(Stream.single(2)));
-    }
+  @Test
+  void testInsertLeft() {
+    Zipper<Integer> z = Zipper.single(2);
+    z = z.insertLeft(1);
+    assertThat(z.lefts(), is(Stream.nil()));
+    assertThat(z.focus(), is(1));
+    assertThat(z.rights(), is(Stream.single(2)));
+  }
 
-    @Test
-    public void testInsertRight() {
-        Zipper<Integer> z = Zipper.single(2);
-        z = z.insertRight(3);
-        assertThat(z.lefts(), is(Stream.single(2)));
-        assertThat(z.focus(), is(3));
-        assertThat(z.rights(), is(Stream.nil()));
-    }
+  @Test
+  void testInsertRight() {
+    Zipper<Integer> z = Zipper.single(2);
+    z = z.insertRight(3);
+    assertThat(z.lefts(), is(Stream.single(2)));
+    assertThat(z.focus(), is(3));
+    assertThat(z.rights(), is(Stream.nil()));
+  }
 
-    @Test
-    public void testDeleteOthers() {
-        Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
-        z = z.deleteOthers();
-        assertThat(z.lefts(), is(Stream.nil()));
-        assertThat(z.focus(), is(2));
-        assertThat(z.rights(), is(Stream.nil()));
-    }
+  @Test
+  void testDeleteOthers() {
+    Zipper<Integer> z = Zipper.zipper(Stream.single(1), 2, Stream.single(3));
+    z = z.deleteOthers();
+    assertThat(z.lefts(), is(Stream.nil()));
+    assertThat(z.focus(), is(2));
+    assertThat(z.rights(), is(Stream.nil()));
+  }
 
-    @Test
-    public void testFind() {
-        Zipper<Integer> z = Zipper.zipper(Stream.nil(), 0, Stream.range(1));
-        z = z.find(i -> i == 4).some();
-        assertThat(z.lefts(), is(Stream.arrayStream(new Integer[]{3, 2, 1, 0})));
-        assertThat(z.focus(), is(4));
-        assertThat(z.rights().take(3), is(Stream.range(5, 8)));
-    }
+  @Test
+  void testFind() {
+    Zipper<Integer> z = Zipper.zipper(Stream.nil(), 0, Stream.range(1));
+    z = z.find(i -> i == 4).some();
+    assertThat(z.lefts(), is(Stream.arrayStream(new Integer[]{3, 2, 1, 0})));
+    assertThat(z.focus(), is(4));
+    assertThat(z.rights().take(3), is(Stream.range(5, 8)));
+  }
 }

--- a/core/src/test/java/fj/data/hamt/HamtTest.java
+++ b/core/src/test/java/fj/data/hamt/HamtTest.java
@@ -4,7 +4,8 @@ import fj.Ord;
 import fj.P2;
 import fj.data.List;
 import fj.data.Option;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Equal.intEqual;
 import static fj.Equal.optionEqual;
@@ -20,48 +21,48 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class HamtTest {
 
-    public static final HashArrayMappedTrie<Integer, Integer> empty = HashArrayMappedTrie.emptyKeyInteger();
+  public static final HashArrayMappedTrie<Integer, Integer> empty = HashArrayMappedTrie.emptyKeyInteger();
 
-    @Test
-    public void empty() {
-        assertThat(empty.length(), equalTo(0));
-    }
+  @Test
+  void empty() {
+    assertThat(empty.length(), equalTo(0));
+  }
 
-    @Test
-    public void lengthOne() {
-        assertThat(empty.set(3, 6).length(), equalTo(1));
-    }
+  @Test
+  void lengthOne() {
+    assertThat(empty.set(3, 6).length(), equalTo(1));
+  }
 
-    @Test
-    public void updateLength() {
-        HashArrayMappedTrie<Integer, Integer> h1 = empty.set(3, 3).set(3, 5);
-        assertThat(h1.length(), equalTo(1));
-    }
+  @Test
+  void updateLength() {
+    HashArrayMappedTrie<Integer, Integer> h1 = empty.set(3, 3).set(3, 5);
+    assertThat(h1.length(), equalTo(1));
+  }
 
-    @Test
-    public void streamLength() {
-        List<P2<Integer, Integer>> list = list(p(0, 1), p(31, 1), p(32, 1), p(33, 1));
-        HashArrayMappedTrie<Integer, Integer> h2 = empty.set(list);
-        assertThat(h2.toStream().length(), equalTo(list.length()));
-    }
+  @Test
+  void streamLength() {
+    List<P2<Integer, Integer>> list = list(p(0, 1), p(31, 1), p(32, 1), p(33, 1));
+    HashArrayMappedTrie<Integer, Integer> h2 = empty.set(list);
+    assertThat(h2.toStream().length(), equalTo(list.length()));
+  }
 
-    @Test
-    public void allIn() {
-        List<P2<Integer, Integer>> list = List.list(p(-5, 0), p(-1, -5), p(2, 4), p(4, -2));
-        HashArrayMappedTrie<Integer, Integer> h = empty.set(list);
-        Boolean b = list.foldLeft((acc, p) -> h.find(p._1()).option(false, i -> true && acc), true);
-        assertThat(b, equalTo(true));
-    }
+  @Test
+  void allIn() {
+    List<P2<Integer, Integer>> list = List.list(p(-5, 0), p(-1, -5), p(2, 4), p(4, -2));
+    HashArrayMappedTrie<Integer, Integer> h = empty.set(list);
+    Boolean b = list.foldLeft((acc, p) -> h.find(p._1()).option(false, i -> true && acc), true);
+    assertThat(b, equalTo(true));
+  }
 
-    @Test
-    public void sampleInts() {
-        List<P2<Integer, Integer>> ps = List.list(p(-3, 0), p(1, 2));
-        int key = -3;
-        HashArrayMappedTrie<Integer, Integer> h = empty.set(ps);
-        Option<Integer> o1 = ps.find(p -> intEqual.eq(p._1(), key)).map(p -> p._2());
-        Option<Integer> o2 = h.find(key);
-        boolean b = optionEqual(intEqual).eq(o1, o2);
-        assertThat(b, equalTo(true));
-    }
+  @Test
+  void sampleInts() {
+    List<P2<Integer, Integer>> ps = List.list(p(-3, 0), p(1, 2));
+    int key = -3;
+    HashArrayMappedTrie<Integer, Integer> h = empty.set(ps);
+    Option<Integer> o1 = ps.find(p -> intEqual.eq(p._1(), key)).map(p -> p._2());
+    Option<Integer> o2 = h.find(key);
+    boolean b = optionEqual(intEqual).eq(o1, o2);
+    assertThat(b, equalTo(true));
+  }
 
 }

--- a/core/src/test/java/fj/data/optic/IsoTest.java
+++ b/core/src/test/java/fj/data/optic/IsoTest.java
@@ -2,43 +2,44 @@ package fj.data.optic;
 
 import fj.P;
 import fj.P2;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class IsoTest {
-    @Test
-    public void testIso() {
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Iso<Address, P2<Integer, String>> addressIso = Iso.iso(p -> P.p(p.number, p.street),
-                p -> new Address(p._1(), p._2()));
-        final Address a = addressIso.reverseGet(addressIso.get(oldAddress));
-        assertThat(a.number, is(oldAddress.number));
-        assertThat(a.street, is(oldAddress.street));
+  @Test
+  void testIso() {
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Iso<Address, P2<Integer, String>> addressIso = Iso.iso(p -> P.p(p.number, p.street),
+        p -> new Address(p._1(), p._2()));
+    final Address a = addressIso.reverseGet(addressIso.get(oldAddress));
+    assertThat(a.number, is(oldAddress.number));
+    assertThat(a.street, is(oldAddress.street));
+  }
+
+  static final class Person {
+    String name;
+    Address address;
+
+    Person(String name, Address address) {
+      this.name = name;
+      this.address = address;
     }
+  }
 
-    static final class Person {
-        String name;
-        Address address;
+  static final class Address {
+    int number;
+    String street;
 
-        Person(String name, Address address) {
-            this.name = name;
-            this.address = address;
-        }
+    public Address(int number, String street) {
+      this.number = number;
+      this.street = street;
     }
-
-    static final class Address {
-        int number;
-        String street;
-
-        public Address(int number, String street) {
-            this.number = number;
-            this.street = street;
-        }
-    }
+  }
 
 }

--- a/core/src/test/java/fj/data/optic/LensTest.java
+++ b/core/src/test/java/fj/data/optic/LensTest.java
@@ -1,124 +1,125 @@
 package fj.data.optic;
 
 import fj.F;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class LensTest {
-    @Test
-    public void testLensPersonGet() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
-        final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
-        final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
-        final Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
-        final Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
-        final Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
-        assertThat(personNameLens.get(oldPerson), is(oldName));
-        assertThat(personNumberLens.get(oldPerson), is(oldNumber));
-        assertThat(personStreetLens.get(oldPerson), is(oldStreet));
+  @Test
+  void testLensPersonGet() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
+    final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
+    final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
+    final Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
+    final Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
+    final Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
+    assertThat(personNameLens.get(oldPerson), is(oldName));
+    assertThat(personNumberLens.get(oldPerson), is(oldNumber));
+    assertThat(personStreetLens.get(oldPerson), is(oldStreet));
+  }
+
+  @Test
+  void testLensPersonSetName() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
+    String newName = "Bill";
+    Person p = personNameLens.set(newName).f(oldPerson);
+    assertThat(p.name, is(newName));
+    assertThat(p.address, is(oldPerson.address));
+  }
+
+  @Test
+  void testLensPersonSetNumber() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
+    final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
+    final Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
+    int newNumber = 20;
+    Person p = personNumberLens.set(newNumber).f(oldPerson);
+    assertThat(p.name, is(oldName));
+    assertThat(p.address.number, is(newNumber));
+    assertThat(p.address.street, is(oldStreet));
+  }
+
+  @Test
+  void testLensPersonSetStreet() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
+    final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
+    final Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
+    final Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
+    String newStreet = "First St";
+    Person p = personStreetLens.set(newStreet).f(oldPerson);
+    assertThat(p.name, is(oldName));
+    assertThat(p.address.number, is(oldPerson.address.number));
+    assertThat(p.address.street, is(newStreet));
+  }
+
+  @Test
+  void testLensPersonSetter() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
+    String newName = "Bill";
+    F<Person, Person> setter = personNameLens.asSetter().set(newName);
+    Person p = setter.f(oldPerson);
+    assertThat(p.name, is(newName));
+    assertThat(p.address, is(oldPerson.address));
+  }
+
+  @Test
+  void testLensPersonGetter() {
+    final String oldName = "Joe";
+    final int oldNumber = 10;
+    final String oldStreet = "Main St";
+    final Address oldAddress = new Address(oldNumber, oldStreet);
+    final Person oldPerson = new Person(oldName, oldAddress);
+    final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
+    assertThat(personNameLens.asGetter().get(oldPerson), is(oldName));
+  }
+
+  static final class Person {
+    String name;
+    Address address;
+
+    Person(String name, Address address) {
+      this.name = name;
+      this.address = address;
     }
+  }
 
-    @Test
-    public void testLensPersonSetName() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
-        String newName = "Bill";
-        Person p = personNameLens.set(newName).f(oldPerson);
-        assertThat(p.name, is(newName));
-        assertThat(p.address, is(oldPerson.address));
+  static final class Address {
+    int number;
+    String street;
+
+    public Address(int number, String street) {
+      this.number = number;
+      this.street = street;
     }
-
-    @Test
-    public void testLensPersonSetNumber() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
-        final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
-        final Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
-        int newNumber = 20;
-        Person p = personNumberLens.set(newNumber).f(oldPerson);
-        assertThat(p.name, is(oldName));
-        assertThat(p.address.number, is(newNumber));
-        assertThat(p.address.street, is(oldStreet));
-    }
-
-    @Test
-    public void testLensPersonSetStreet() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
-        final Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
-        final Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
-        final Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
-        String newStreet = "First St";
-        Person p = personStreetLens.set(newStreet).f(oldPerson);
-        assertThat(p.name, is(oldName));
-        assertThat(p.address.number, is(oldPerson.address.number));
-        assertThat(p.address.street, is(newStreet));
-    }
-
-    @Test
-    public void testLensPersonSetter() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
-        String newName = "Bill";
-        F<Person, Person> setter = personNameLens.asSetter().set(newName);
-        Person p = setter.f(oldPerson);
-        assertThat(p.name, is(newName));
-        assertThat(p.address, is(oldPerson.address));
-    }
-
-    @Test
-    public void testLensPersonGetter() {
-        final String oldName = "Joe";
-        final int oldNumber = 10;
-        final String oldStreet = "Main St";
-        final Address oldAddress = new Address(oldNumber, oldStreet);
-        final Person oldPerson = new Person(oldName, oldAddress);
-        final Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
-        assertThat(personNameLens.asGetter().get(oldPerson), is(oldName));
-    }
-
-    static final class Person {
-        String name;
-        Address address;
-
-        Person(String name, Address address) {
-            this.name = name;
-            this.address = address;
-        }
-    }
-
-    static final class Address {
-        int number;
-        String street;
-
-        public Address(int number, String street) {
-            this.number = number;
-            this.street = street;
-        }
-    }
+  }
 
 }

--- a/core/src/test/java/fj/data/optic/OptionalTest.java
+++ b/core/src/test/java/fj/data/optic/OptionalTest.java
@@ -1,30 +1,31 @@
 package fj.data.optic;
 
 import fj.data.Option;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class OptionalTest {
-    @Test
-    public void testOptionalSome() {
-        Optional<String, Integer> o = Optional.optional(this::decode, i -> s -> s);
-        assertThat(o.getOption("18"), is(Option.some(18)));
-    }
+  @Test
+  void testOptionalSome() {
+    Optional<String, Integer> o = Optional.optional(this::decode, i -> s -> s);
+    assertThat(o.getOption("18"), is(Option.some(18)));
+  }
 
-    @Test
-    public void testOptionalNone() {
-        Optional<String, Integer> o = Optional.optional(this::decode, i -> s -> s);
-        assertThat(o.getOption("Z"), is(Option.none()));
-    }
+  @Test
+  void testOptionalNone() {
+    Optional<String, Integer> o = Optional.optional(this::decode, i -> s -> s);
+    assertThat(o.getOption("Z"), is(Option.none()));
+  }
 
-    private Option<Integer> decode(String s) {
-        try {
-            return Option.some(Integer.decode(s));
-        } catch (NumberFormatException nfe) {
-            return Option.none();
-        }
+  private Option<Integer> decode(String s) {
+    try {
+      return Option.some(Integer.decode(s));
+    } catch (NumberFormatException nfe) {
+      return Option.none();
     }
+  }
 }

--- a/core/src/test/java/fj/data/optic/PrismTest.java
+++ b/core/src/test/java/fj/data/optic/PrismTest.java
@@ -1,29 +1,30 @@
 package fj.data.optic;
 
 import fj.data.Option;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PrismTest {
-    @Test
-    public void testPrismSome() {
-        Prism<String, Integer> prism = Prism.prism(s -> decode(s), i -> i.toString());
-        assertThat(prism.getOption("18"), is(Option.some(18)));
-    }
+  @Test
+  void testPrismSome() {
+    Prism<String, Integer> prism = Prism.prism(s -> decode(s), i -> i.toString());
+    assertThat(prism.getOption("18"), is(Option.some(18)));
+  }
 
-    @Test
-    public void testPrismNone() {
-        Prism<String, Integer> prism = Prism.prism(s -> decode(s), i -> i.toString());
-        assertThat(prism.getOption("Z"), is(Option.none()));
-    }
+  @Test
+  void testPrismNone() {
+    Prism<String, Integer> prism = Prism.prism(s -> decode(s), i -> i.toString());
+    assertThat(prism.getOption("Z"), is(Option.none()));
+  }
 
-    private Option<Integer> decode(String s) {
-        try {
-            return Option.some(Integer.decode(s));
-        } catch (NumberFormatException nfe) {
-            return Option.none();
-        }
+  private Option<Integer> decode(String s) {
+    try {
+      return Option.some(Integer.decode(s));
+    } catch (NumberFormatException nfe) {
+      return Option.none();
     }
+  }
 }

--- a/core/src/test/java/fj/data/optic/TraversalTest.java
+++ b/core/src/test/java/fj/data/optic/TraversalTest.java
@@ -2,22 +2,23 @@ package fj.data.optic;
 
 import fj.Monoid;
 import fj.data.Either;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TraversalTest {
-    @Test
-    public void testTraversalLeft() {
-        final Traversal<Either<Integer, Integer>, Integer> t = Traversal.codiagonal();
-        assertThat(t.fold(Monoid.intMinMonoid).f(Either.left(3)), is(3));
-    }
+  @Test
+  void testTraversalLeft() {
+    final Traversal<Either<Integer, Integer>, Integer> t = Traversal.codiagonal();
+    assertThat(t.fold(Monoid.intMinMonoid).f(Either.left(3)), is(3));
+  }
 
-    @Test
-    public void testTraversalRight() {
-        final Traversal<Either<Integer, Integer>, Integer> t = Traversal.codiagonal();
-        assertThat(t.fold(Monoid.intMinMonoid).f(Either.right(2)), is(2));
-    }
+  @Test
+  void testTraversalRight() {
+    final Traversal<Either<Integer, Integer>, Integer> t = Traversal.codiagonal();
+    assertThat(t.fold(Monoid.intMinMonoid).f(Either.right(2)), is(2));
+  }
 
 }

--- a/core/src/test/java/fj/data/vector/VTest.java
+++ b/core/src/test/java/fj/data/vector/VTest.java
@@ -2,106 +2,107 @@ package fj.data.vector;
 
 import fj.*;
 import fj.data.Array;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class VTest {
-    @Test
-    public void testVectorUp(){
-        final P2<Integer, Integer> p2 = P.p(2, 1);
-        final V2<Integer> v2 = V2.p(p2);
-        final V3<Integer> v3 = V3.cons(P.p(3), v2);
-        final V4<Integer> v4 = V4.cons(P.p(4), v3);
-        final V5<Integer> v5 = V5.cons(P.p(5), v4);
-        final V6<Integer> v6 = V6.cons(P.p(6), v5);
-        final V7<Integer> v7 = V7.cons(P.p(7), v6);
-        final V8<Integer> v8 = V8.cons(P.p(8), v7);
-        assertThat(v8.toArray(), is(Array.range(1, 9).reverse()));
-    }
+  @Test
+  void testVectorUp() {
+    final P2<Integer, Integer> p2 = P.p(2, 1);
+    final V2<Integer> v2 = V2.p(p2);
+    final V3<Integer> v3 = V3.cons(P.p(3), v2);
+    final V4<Integer> v4 = V4.cons(P.p(4), v3);
+    final V5<Integer> v5 = V5.cons(P.p(5), v4);
+    final V6<Integer> v6 = V6.cons(P.p(6), v5);
+    final V7<Integer> v7 = V7.cons(P.p(7), v6);
+    final V8<Integer> v8 = V8.cons(P.p(8), v7);
+    assertThat(v8.toArray(), is(Array.range(1, 9).reverse()));
+  }
 
-    @Test
-    public void testVectorP(){
-        final P2<Integer, Integer> p2 = P.p(1, 2);
-        final V2<Integer> v2 = V2.p(p2);
-        assertThat(v2.toArray(), is(Array.range(1, 3)));
-        assertThat(v2.p(), is(p2));
-        final P3<Integer, Integer, Integer> p3 = p2.append(3);
-        final V3<Integer> v3 = V3.p(p3);
-        assertThat(v3.toArray(), is(Array.range(1, 4)));
-        assertThat(v3.p(), is(p3));
-        final P4<Integer, Integer, Integer, Integer> p4 = p3.append(4);
-        final V4<Integer> v4 = V4.p(p4);
-        assertThat(v4.toArray(), is(Array.range(1, 5)));
-        assertThat(v4.p(), is(p4));
-        final P5<Integer, Integer, Integer, Integer, Integer> p5 = p4.append(5);
-        final V5<Integer> v5 = V5.p(p5);
-        assertThat(v5.toArray(), is(Array.range(1, 6)));
-        assertThat(v5.p(), is(p5));
-        final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = p5.append(6);
-        final V6<Integer> v6 = V6.p(p6);
-        assertThat(v6.toArray(), is(Array.range(1, 7)));
-        assertThat(v6.p(), is(p6));
-        final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 = p6.append(7);
-        final V7<Integer> v7 = V7.p(p7);
-        assertThat(v7.toArray(), is(Array.range(1, 8)));
-        assertThat(v7.p(), is(p7));
-        final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 = p7.append(8);
-        final V8<Integer> v8 = V8.p(p8);
-        assertThat(v8.toArray(), is(Array.range(1, 9)));
-        assertThat(v8.p(), is(p8));
-    }
+  @Test
+  void testVectorP() {
+    final P2<Integer, Integer> p2 = P.p(1, 2);
+    final V2<Integer> v2 = V2.p(p2);
+    assertThat(v2.toArray(), is(Array.range(1, 3)));
+    assertThat(v2.p(), is(p2));
+    final P3<Integer, Integer, Integer> p3 = p2.append(3);
+    final V3<Integer> v3 = V3.p(p3);
+    assertThat(v3.toArray(), is(Array.range(1, 4)));
+    assertThat(v3.p(), is(p3));
+    final P4<Integer, Integer, Integer, Integer> p4 = p3.append(4);
+    final V4<Integer> v4 = V4.p(p4);
+    assertThat(v4.toArray(), is(Array.range(1, 5)));
+    assertThat(v4.p(), is(p4));
+    final P5<Integer, Integer, Integer, Integer, Integer> p5 = p4.append(5);
+    final V5<Integer> v5 = V5.p(p5);
+    assertThat(v5.toArray(), is(Array.range(1, 6)));
+    assertThat(v5.p(), is(p5));
+    final P6<Integer, Integer, Integer, Integer, Integer, Integer> p6 = p5.append(6);
+    final V6<Integer> v6 = V6.p(p6);
+    assertThat(v6.toArray(), is(Array.range(1, 7)));
+    assertThat(v6.p(), is(p6));
+    final P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> p7 = p6.append(7);
+    final V7<Integer> v7 = V7.p(p7);
+    assertThat(v7.toArray(), is(Array.range(1, 8)));
+    assertThat(v7.p(), is(p7));
+    final P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> p8 = p7.append(8);
+    final V8<Integer> v8 = V8.p(p8);
+    assertThat(v8.toArray(), is(Array.range(1, 9)));
+    assertThat(v8.p(), is(p8));
+  }
 
-    @Test
-    public void testVectorFunc2() {
-        V2<Integer> v2 = V.v(() -> 2, () -> 1);
-        F2<Integer, Integer, V2<Integer>> fv2 = V.v2();
-        V2<Integer> vf2 = fv2.f(2, 1);
-        assertThat(vf2, is(v2));
-    }
+  @Test
+  void testVectorFunc2() {
+    V2<Integer> v2 = V.v(() -> 2, () -> 1);
+    F2<Integer, Integer, V2<Integer>> fv2 = V.v2();
+    V2<Integer> vf2 = fv2.f(2, 1);
+    assertThat(vf2, is(v2));
+  }
 
-    @Test
-    public void testVectorFunc3() {
-        V3<Integer> v3 = V.v(P.p(3), () -> 2, () -> 1);
-        F3<Integer, Integer, Integer, V3<Integer>> fv3 = V.v3();
-        V3<Integer> vf3 = fv3.f(3, 2, 1);
-        assertThat(vf3, is(v3));
-    }
+  @Test
+  void testVectorFunc3() {
+    V3<Integer> v3 = V.v(P.p(3), () -> 2, () -> 1);
+    F3<Integer, Integer, Integer, V3<Integer>> fv3 = V.v3();
+    V3<Integer> vf3 = fv3.f(3, 2, 1);
+    assertThat(vf3, is(v3));
+  }
 
-    @Test
-    public void testVectorFunc4() {
-        V4<Integer> v4 = V.v(P.p(4), P.p(3), () -> 2, () -> 1);
-        F4<Integer, Integer, Integer, Integer, V4<Integer>> fv4 = V.v4();
-        V4<Integer> vf4 = fv4.f(4, 3, 2, 1);
-        assertThat(vf4, is(v4));
-    }
+  @Test
+  void testVectorFunc4() {
+    V4<Integer> v4 = V.v(P.p(4), P.p(3), () -> 2, () -> 1);
+    F4<Integer, Integer, Integer, Integer, V4<Integer>> fv4 = V.v4();
+    V4<Integer> vf4 = fv4.f(4, 3, 2, 1);
+    assertThat(vf4, is(v4));
+  }
 
-    @Test
-    public void testVectorFunc5() {
-        V5<Integer> v5 = V.v(P.p(5), P.p(4), P.p(3), () -> 2, () -> 1);
-        F5<Integer, Integer, Integer, Integer, Integer, V5<Integer>> fv5 = V.v5();
-        V5<Integer> vf5 = fv5.f(5, 4, 3, 2, 1);
-        assertThat(vf5, is(v5));
-    }
+  @Test
+  void testVectorFunc5() {
+    V5<Integer> v5 = V.v(P.p(5), P.p(4), P.p(3), () -> 2, () -> 1);
+    F5<Integer, Integer, Integer, Integer, Integer, V5<Integer>> fv5 = V.v5();
+    V5<Integer> vf5 = fv5.f(5, 4, 3, 2, 1);
+    assertThat(vf5, is(v5));
+  }
 
-    @Test
-    public void testVectorMap() {
-        final V2<Integer> v2 = V.v(() -> 2, () -> 1);
-        assertThat(v2, is(v2.map(i -> i * 1)));
-        final V3<Integer> v3 = V3.cons(P.p(3), v2);
-        assertThat(v3, is(v3.map(i -> i * 1)));
-        final V4<Integer> v4 = V4.cons(P.p(4), v3);
-        assertThat(v4, is(v4.map(i -> i * 1)));
-        final V5<Integer> v5 = V5.cons(P.p(5), v4);
-        assertThat(v5, is(v5.map(i -> i * 1)));
-        final V6<Integer> v6 = V6.cons(P.p(6), v5);
-        assertThat(v6, is(v6.map(i -> i * 1)));
-        final V7<Integer> v7 = V7.cons(P.p(7), v6);
-        assertThat(v7, is(v7.map(i -> i * 1)));
-        final V8<Integer> v8 = V8.cons(P.p(8), v7);
-        assertThat(v8, is(v8.map(i -> i * 1)));
-    }
+  @Test
+  void testVectorMap() {
+    final V2<Integer> v2 = V.v(() -> 2, () -> 1);
+    assertThat(v2, is(v2.map(i -> i * 1)));
+    final V3<Integer> v3 = V3.cons(P.p(3), v2);
+    assertThat(v3, is(v3.map(i -> i * 1)));
+    final V4<Integer> v4 = V4.cons(P.p(4), v3);
+    assertThat(v4, is(v4.map(i -> i * 1)));
+    final V5<Integer> v5 = V5.cons(P.p(5), v4);
+    assertThat(v5, is(v5.map(i -> i * 1)));
+    final V6<Integer> v6 = V6.cons(P.p(6), v5);
+    assertThat(v6, is(v6.map(i -> i * 1)));
+    final V7<Integer> v7 = V7.cons(P.p(7), v6);
+    assertThat(v7, is(v7.map(i -> i * 1)));
+    final V8<Integer> v8 = V8.cons(P.p(8), v7);
+    assertThat(v8, is(v8.map(i -> i * 1)));
+  }
 
 }

--- a/core/src/test/java/fj/function/DoublesTest.java
+++ b/core/src/test/java/fj/function/DoublesTest.java
@@ -1,64 +1,62 @@
 package fj.function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-
-
 import fj.F;
-import org.junit.Test;
 
 import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.hamcrest.core.Is.is;
 
 import static fj.data.List.list;
 
 public class DoublesTest {
 
-    @Test
-    public void testSum() {
-        assertThat(Doubles.sum(list(3.0, 4.0, 5.0)), is(12.0));
-    }
+  @Test
+  void testSum() {
+    assertThat(Doubles.sum(list(3.0, 4.0, 5.0)), is(12.0));
+  }
 
-    @Test
-    public void testProduct() {
-        assertThat(Doubles.product(list(3.0, 4.0, 5.0)), is(60.0));
-    }
+  @Test
+  void testProduct() {
+    assertThat(Doubles.product(list(3.0, 4.0, 5.0)), is(60.0));
+  }
 
-    @Test
-    public void testAdd() {
-        assertThat(Doubles.add.f(10.0).f(20.0), is(30.0));
-    }
+  @Test
+  void testAdd() {
+    assertThat(Doubles.add.f(10.0).f(20.0), is(30.0));
+  }
 
-    @Test
-    public void testMultiply() {
-        assertThat(Doubles.multiply.f(3.0).f(5.0), is(15.0));
-    }
+  @Test
+  void testMultiply() {
+    assertThat(Doubles.multiply.f(3.0).f(5.0), is(15.0));
+  }
 
-    @Test
-    public void testAbs() {
-        assertThat(Doubles.abs.f(-5.0), is(5.0));
-    }
+  @Test
+  void testAbs() {
+    assertThat(Doubles.abs.f(-5.0), is(5.0));
+  }
 
-    @Test
-    public void testFromString() {
-        assertThat(Doubles.fromString().f("-123.45").some(), is(-123.45));
-    }
+  @Test
+  void testFromString() {
+    assertThat(Doubles.fromString().f("-123.45").some(), is(-123.45));
+  }
 
-    @Test
-    public void testCannotInstantiate() throws NoSuchMethodException, InvocationTargetException,
-            IllegalAccessException, InstantiationException {
-        Constructor<Doubles> constructor = Doubles.class.getDeclaredConstructor(new Class[0]);
-        constructor.setAccessible(true);
-        try {
-            constructor.newInstance(new Object[0]);
-            fail("expected InvocationTargetException");
-        } catch (InvocationTargetException ite) {
-            assertTrue(ite.getCause() instanceof UnsupportedOperationException);
-        }
+  @Test
+  void testCannotInstantiate() throws NoSuchMethodException, InvocationTargetException,
+      IllegalAccessException, InstantiationException {
+    Constructor<Doubles> constructor = Doubles.class.getDeclaredConstructor(new Class[0]);
+    constructor.setAccessible(true);
+    try {
+      constructor.newInstance(new Object[0]);
+      fail("expected InvocationTargetException");
+    } catch (InvocationTargetException ite) {
+      assertTrue(ite.getCause() instanceof UnsupportedOperationException);
     }
+  }
 
 }

--- a/core/src/test/java/fj/function/IntegersTest.java
+++ b/core/src/test/java/fj/function/IntegersTest.java
@@ -1,6 +1,6 @@
 package fj.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -8,58 +8,57 @@ import java.lang.reflect.InvocationTargetException;
 import static fj.data.List.list;
 import static fj.data.Option.none;
 import static org.hamcrest.core.Is.is;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class IntegersTest {
 
-    @Test
-    public void testSum() {
-        assertThat(Integers.sum(list(3, 4, 5)), is(12));
-    }
+  @Test
+  void testSum() {
+    assertThat(Integers.sum(list(3, 4, 5)), is(12));
+  }
 
-    @Test
-    public void testProduct() {
-        assertThat(Integers.product(list(3, 4, 5)), is(60));
-    }
+  @Test
+  void testProduct() {
+    assertThat(Integers.product(list(3, 4, 5)), is(60));
+  }
 
-    @Test
-    public void testAdd() {
-        assertThat(Integers.add.f(10).f(20), is(30));
-    }
+  @Test
+  void testAdd() {
+    assertThat(Integers.add.f(10).f(20), is(30));
+  }
 
-    @Test
-    public void testMultiply() {
-        assertThat(Integers.multiply.f(3).f(5), is(15));
-    }
+  @Test
+  void testMultiply() {
+    assertThat(Integers.multiply.f(3).f(5), is(15));
+  }
 
-    @Test
-    public void testAbs() {
-        assertThat(Integers.abs.f(-5), is(5));
-    }
+  @Test
+  void testAbs() {
+    assertThat(Integers.abs.f(-5), is(5));
+  }
 
-    @Test
-    public void testFromString() {
-        assertThat(Integers.fromString().f("-123").some(), is(-123));
-    }
+  @Test
+  void testFromString() {
+    assertThat(Integers.fromString().f("-123").some(), is(-123));
+  }
 
-    @Test
-    public void testFromStringFail() {
-        assertThat(Integers.fromString().f("w"), is(none()));
-    }
+  @Test
+  void testFromStringFail() {
+    assertThat(Integers.fromString().f("w"), is(none()));
+  }
 
-    @Test
-    public void testCannotInstantiate() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
-        Constructor<Integers> constructor = Integers.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        try {
-            constructor.newInstance();
-            fail("expected InvocationTargetException");
-        } catch (InvocationTargetException ite) {
-            assertTrue(ite.getCause() instanceof UnsupportedOperationException);
-        }
+  @Test
+  void testCannotInstantiate() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    Constructor<Integers> constructor = Integers.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    try {
+      constructor.newInstance();
+      fail("expected InvocationTargetException");
+    } catch (InvocationTargetException ite) {
+      assertTrue(ite.getCause() instanceof UnsupportedOperationException);
     }
+  }
 
 }

--- a/core/src/test/java/fj/function/LongsTest.java
+++ b/core/src/test/java/fj/function/LongsTest.java
@@ -1,6 +1,6 @@
 package fj.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -8,58 +8,58 @@ import java.lang.reflect.InvocationTargetException;
 import static fj.data.List.list;
 import static fj.data.Option.none;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class LongsTest {
 
-    @Test
-    public void testSum() {
-        assertThat(Longs.sum(list(3L, 4L, 5L)), is(12L));
-    }
+  @Test
+  void testSum() {
+    assertThat(Longs.sum(list(3L, 4L, 5L)), is(12L));
+  }
 
-    @Test
-    public void testProduct() {
-        assertThat(Longs.product(list(3L, 4L, 5L)), is(60L));
-    }
+  @Test
+  void testProduct() {
+    assertThat(Longs.product(list(3L, 4L, 5L)), is(60L));
+  }
 
-    @Test
-    public void testAdd() {
-        assertThat(Longs.add.f(10L).f(20L), is(30L));
-    }
+  @Test
+  void testAdd() {
+    assertThat(Longs.add.f(10L).f(20L), is(30L));
+  }
 
-    @Test
-    public void testMultiply() {
-        assertThat(Longs.multiply.f(3L).f(5L), is(15L));
-    }
+  @Test
+  void testMultiply() {
+    assertThat(Longs.multiply.f(3L).f(5L), is(15L));
+  }
 
-    @Test
-    public void testAbs() {
-        assertThat(Longs.abs.f(-5L), is(5L));
-    }
+  @Test
+  void testAbs() {
+    assertThat(Longs.abs.f(-5L), is(5L));
+  }
 
-    @Test
-    public void testFromString() {
-        assertThat(Longs.fromString().f("-123").some(), is(-123L));
-    }
+  @Test
+  void testFromString() {
+    assertThat(Longs.fromString().f("-123").some(), is(-123L));
+  }
 
-    @Test
-    public void testFromStringFail() {
-        assertThat(Longs.fromString().f("w"), is(none()));
-    }
+  @Test
+  void testFromStringFail() {
+    assertThat(Longs.fromString().f("w"), is(none()));
+  }
 
-    @Test
-    public void testCannotInstantiate() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
-        Constructor<Longs> constructor = Longs.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        try {
-            constructor.newInstance();
-            fail("expected InvocationTargetException");
-        } catch (InvocationTargetException ite) {
-            assertTrue(ite.getCause() instanceof UnsupportedOperationException);
-        }
+  @Test
+  void testCannotInstantiate() throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    Constructor<Longs> constructor = Longs.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    try {
+      constructor.newInstance();
+      fail("expected InvocationTargetException");
+    } catch (InvocationTargetException ite) {
+      assertTrue(ite.getCause() instanceof UnsupportedOperationException);
     }
+  }
 
 }

--- a/core/src/test/java/fj/function/StringsTest.java
+++ b/core/src/test/java/fj/function/StringsTest.java
@@ -1,68 +1,71 @@
 package fj.function;
 
 import fj.Function;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Function.compose;
 import static fj.function.Strings.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class StringsTest {
-    @Test
-    public void testLines() {
-        assertThat(compose(unlines(), lines()).f("one two three"), is("one two three"));
-    }
+  @Test
+  void testLines() {
+    assertThat(compose(unlines(), lines()).f("one two three"), is("one two three"));
+  }
 
-    @Test
-    public void testLinesEmpty() {
-        assertThat(unlines().o(lines()).f(""), is(""));
-    }
+  @Test
+  void testLinesEmpty() {
+    assertThat(unlines().o(lines()).f(""), is(""));
+  }
 
-    @Test
-    public void testLength() {
-        assertThat(length.f("functionaljava"), is(14));
-    }
+  @Test
+  void testLength() {
+    assertThat(length.f("functionaljava"), is(14));
+  }
 
-    @Test
-    public void testMatches() {
-        assertThat(matches.f("foo").f("foo"), is(true));
-    }
+  @Test
+  void testMatches() {
+    assertThat(matches.f("foo").f("foo"), is(true));
+  }
 
-    @Test
-    public void testContains() {
-        assertThat(contains.f("bar").f("foobar1"), is(true));
-    }
+  @Test
+  void testContains() {
+    assertThat(contains.f("bar").f("foobar1"), is(true));
+  }
 
-    @Test(expected = NullPointerException.class)
-    public void testIsEmptyException() {
-        assertThat(isEmpty.f(null), is(true));
-    }
+  @Test
+  void testIsEmptyException() {
+    assertThrows(NullPointerException.class, () -> {
+      assertThat(isEmpty.f(null), is(true));
+    });
+  }
 
-    @Test
-    public void testIsEmpty() {
-        assertThat(isEmpty.f(""), is(true));
-    }
+  @Test
+  void testIsEmpty() {
+    assertThat(isEmpty.f(""), is(true));
+  }
 
-    @Test
-    public void testIsNotNullOrEmpty() {
-        assertThat(isNotNullOrEmpty.f("foo"), is(true));
-    }
+  @Test
+  void testIsNotNullOrEmpty() {
+    assertThat(isNotNullOrEmpty.f("foo"), is(true));
+  }
 
-    @Test
-    public void testIsNullOrEmpty() {
-        assertThat(isNullOrEmpty.f(null), is(true));
-    }
+  @Test
+  void testIsNullOrEmpty() {
+    assertThat(isNullOrEmpty.f(null), is(true));
+  }
 
-    @Test
-    public void testIsNotNullOrBlank() {
-        assertThat(isNotNullOrBlank.f("foo"), is(true));
-    }
+  @Test
+  void testIsNotNullOrBlank() {
+    assertThat(isNotNullOrBlank.f("foo"), is(true));
+  }
 
-    @Test
-    public void testIsNullOrBlank() {
-        assertThat(isNullOrBlank.f("  "), is(true));
-    }
+  @Test
+  void testIsNullOrBlank() {
+    assertThat(isNullOrBlank.f("  "), is(true));
+  }
 }

--- a/core/src/test/java/fj/function/TestEffect.java
+++ b/core/src/test/java/fj/function/TestEffect.java
@@ -1,21 +1,21 @@
 package fj.function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestEffect {
 
-	@Test
-	public void test1() {
-		higher(TestEffect::m1);
-	}
+  @Test
+  void test1() {
+    higher(TestEffect::m1);
+  }
 
 
-	static void higher(Effect1<String> f) {
+  static void higher(Effect1<String> f) {
 
-	}
+  }
 
-	static void m1(String s) {
+  static void m1(String s) {
 
-	}
+  }
 
 }

--- a/core/src/test/java/fj/function/VisitorTest.java
+++ b/core/src/test/java/fj/function/VisitorTest.java
@@ -5,7 +5,8 @@ import fj.F;
 import fj.P;
 import fj.P1;
 import fj.data.List;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Option.none;
 import static fj.data.Option.some;
@@ -14,67 +15,67 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VisitorTest {
-    @Test
-    public void testFindFirst() {
-        assertThat(findFirst(List.list(none(), some(1), none()), () -> -1), is(1));
-    }
+  @Test
+  void testFindFirst() {
+    assertThat(findFirst(List.list(none(), some(1), none()), () -> -1), is(1));
+  }
 
-    @Test
-    public void testFindFirstDef() {
-        assertThat(findFirst(List.list(none(), none(), none()), () -> -1), is(-1));
-    }
+  @Test
+  void testFindFirstDef() {
+    assertThat(findFirst(List.list(none(), none(), none()), () -> -1), is(-1));
+  }
 
-    @Test
-    public void testNullableFindFirst() {
-        assertThat(nullablefindFirst(List.list(null, 1, null), () -> -1), is(1));
-    }
+  @Test
+  void testNullableFindFirst() {
+    assertThat(nullablefindFirst(List.list(null, 1, null), () -> -1), is(1));
+  }
 
-    @Test
-    public void testNullableFindFirstDef() {
-        assertThat(nullablefindFirst(List.list(null, null, null), () -> -1), is(-1));
-    }
+  @Test
+  void testNullableFindFirstDef() {
+    assertThat(nullablefindFirst(List.list(null, null, null), () -> -1), is(-1));
+  }
 
-    @Test
-    public void testVisitor() {
-        assertThat(visitor(List.list(i -> some(2 * i)), () -> -1, 10), is(20));
-    }
+  @Test
+  void testVisitor() {
+    assertThat(visitor(List.list(i -> some(2 * i)), () -> -1, 10), is(20));
+  }
 
-    @Test
-    public void testVisitorDef() {
-        assertThat(visitor(List.list(i -> none()), () -> "foo", 10), is("foo"));
-    }
+  @Test
+  void testVisitorDef() {
+    assertThat(visitor(List.list(i -> none()), () -> "foo", 10), is("foo"));
+  }
 
-    @Test
-    public void testNullableVisitor() {
-        assertThat(nullableVisitor(List.list(i -> 2 * i), () -> -1, 10), is(20));
-    }
+  @Test
+  void testNullableVisitor() {
+    assertThat(nullableVisitor(List.list(i -> 2 * i), () -> -1, 10), is(20));
+  }
 
-    @Test
-    public void testNullableVisitorDef() {
-        assertThat(nullableVisitor(List.list(i -> null), () -> "foo", 10), is("foo"));
-    }
+  @Test
+  void testNullableVisitorDef() {
+    assertThat(nullableVisitor(List.list(i -> null), () -> "foo", 10), is("foo"));
+  }
 
-    @Test
-    public void testAssociation() {
-        final F<String, F<Integer, String>> a = association(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
-        assertThat(a.f("foo").f(2), is("two"));
-    }
+  @Test
+  void testAssociation() {
+    final F<String, F<Integer, String>> a = association(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
+    assertThat(a.f("foo").f(2), is("two"));
+  }
 
-    @Test
-    public void testAssociationDef() {
-        final F<String, F<Integer, String>> a = association(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
-        assertThat(a.f("foo").f(3), is("foo"));
-    }
+  @Test
+  void testAssociationDef() {
+    final F<String, F<Integer, String>> a = association(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
+    assertThat(a.f("foo").f(3), is("foo"));
+  }
 
-    @Test
-    public void testAssociationLazy() {
-        final F<P1<String>, F<Integer, String>> a = associationLazy(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
-        assertThat(a.f(P.p("foo")).f(2), is("two"));
-    }
+  @Test
+  void testAssociationLazy() {
+    final F<P1<String>, F<Integer, String>> a = associationLazy(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
+    assertThat(a.f(P.p("foo")).f(2), is("two"));
+  }
 
-    @Test
-    public void testAssociationLazyDef() {
-        final F<P1<String>, F<Integer, String>> a = associationLazy(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
-        assertThat(a.f(P.p("foo")).f(3), is("foo"));
-    }
+  @Test
+  void testAssociationLazyDef() {
+    final F<P1<String>, F<Integer, String>> a = associationLazy(List.list(P.p(1, "one"), P.p(2, "two")), Equal.intEqual);
+    assertThat(a.f(P.p("foo")).f(3), is("foo"));
+  }
 }

--- a/core/src/test/java/fj/parser/ParserTest.java
+++ b/core/src/test/java/fj/parser/ParserTest.java
@@ -4,49 +4,50 @@ import fj.F;
 import fj.F0;
 import fj.data.Stream;
 import fj.data.Validation;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.parser.Result.result;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ParserTest {
-    @Test
-    public void testParserFail() {
-        final Parser<String, String, Exception> fail = Parser.fail(new ParseException());
-        assertThat(fail.parse("").fail(), is(new ParseException()));
-    }
+  @Test
+  void testParserFail() {
+    final Parser<String, String, Exception> fail = Parser.fail(new ParseException());
+    assertThat(fail.parse("").fail(), is(new ParseException()));
+  }
 
-    @Test
-    public void testParserValue() {
-        final Parser<String, String, Exception> p = Parser.parser(s -> s.isEmpty() ?
-                Validation.fail(new ParseException()) :
-                Validation.success(result(s.substring(1), s.substring(0, 1)))
-        );
-        final Result<String, String> r = p.parse("abc").success();
-        assertThat(r.value(), is("a"));
-        assertThat(r.rest(), is("bc"));
-    }
+  @Test
+  void testParserValue() {
+    final Parser<String, String, Exception> p = Parser.parser(s -> s.isEmpty() ?
+            Validation.fail(new ParseException()) :
+            Validation.success(result(s.substring(1), s.substring(0, 1)))
+    );
+    final Result<String, String> r = p.parse("abc").success();
+    assertThat(r.value(), is("a"));
+    assertThat(r.rest(), is("bc"));
+  }
 
-    @Test
-    public void testParserBind() {
-        final Parser<String, String, Exception> p = Parser.value("a");
-        final Parser<String, String, Exception> fail = Parser.fail(new ParseException());
-        assertThat(p.bind(o -> fail).parse("aaaa").fail(), is(new ParseException()));
-    }
+  @Test
+  void testParserBind() {
+    final Parser<String, String, Exception> p = Parser.value("a");
+    final Parser<String, String, Exception> fail = Parser.fail(new ParseException());
+    assertThat(p.bind(o -> fail).parse("aaaa").fail(), is(new ParseException()));
+  }
 
-    @Test
-    public void testParserStream() {
-        Stream<Character> s = Stream.fromString("abc");
-        Result<Stream<Character>, Character> r = Parser.CharsParser.character('a').parse(s).success();
-        assertThat(r, is(Result.result(Stream.fromString("bc"), 'a')));
-    }
+  @Test
+  void testParserStream() {
+    Stream<Character> s = Stream.fromString("abc");
+    Result<Stream<Character>, Character> r = Parser.CharsParser.character('a').parse(s).success();
+    assertThat(r, is(Result.result(Stream.fromString("bc"), 'a')));
+  }
 
-    class ParseException extends Exception {
-        @Override
-        public boolean equals (Object obj) {
-            return (obj instanceof ParseException);
-        }
+  class ParseException extends Exception {
+    @Override
+    public boolean equals(Object obj) {
+      return (obj instanceof ParseException);
     }
+  }
 
 }

--- a/demo/src/main/java/fj/demo/optic/LensPerson.java
+++ b/demo/src/main/java/fj/demo/optic/LensPerson.java
@@ -2,79 +2,80 @@ package fj.demo.optic;
 
 import fj.Equal;
 import fj.data.optic.Lens;
-import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LensPerson {
 
-    static final class Person {
-        String name;
-        Address address;
+  static final class Person {
+    String name;
+    Address address;
 
-        Person(String name, Address address) {
-            this.name = name;
-            this.address = address;
-        }
+    Person(String name, Address address) {
+      this.name = name;
+      this.address = address;
     }
+  }
 
-    static final class Address {
-        int number;
-        String street;
+  static final class Address {
+    int number;
+    String street;
 
-        public Address(int number, String street) {
-            this.number = number;
-            this.street = street;
-        }
+    public Address(int number, String street) {
+      this.number = number;
+      this.street = street;
     }
+  }
 
-    static Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
-    static Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
-    static Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
-    static Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
-    static Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
-    static Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
+  static Lens<Person, String> personNameLens = Lens.lens(p -> p.name, s -> p -> new Person(s, p.address));
+  static Lens<Person, Address> personAddressLens = Lens.lens(p -> p.address, a -> p -> new Person(p.name, a));
+  static Lens<Address, Integer> addressNumberLens = Lens.lens(a -> a.number, n -> a -> new Address(n, a.street));
+  static Lens<Address, String> addressStreetLens = Lens.lens(a -> a.street, s -> a -> new Address(a.number, s));
+  static Lens<Person, Integer> personNumberLens = personAddressLens.composeLens(addressNumberLens);
+  static Lens<Person, String> personStreetLens = personAddressLens.composeLens(addressStreetLens);
 
-    static Equal<Address> addressEqual = Equal.equal(a1 -> a2 -> a1.number == a2.number && a1.street.equals(a2.street));
-    static Equal<Person> personEqual = Equal.equal(p1 -> p2 -> p1.name.equals(p2.name) && addressEqual.eq(p1.address, p2.address));
+  static Equal<Address> addressEqual = Equal.equal(a1 -> a2 -> a1.number == a2.number && a1.street.equals(a2.street));
+  static Equal<Person> personEqual = Equal.equal(p1 -> p2 -> p1.name.equals(p2.name) && addressEqual.eq(p1.address, p2.address));
 
-    static final String oldName = "Joe";
-    static final int oldNumber = 10;
-    static final String oldStreet = "Main St";
-    static final Address oldAddress = new Address(oldNumber, oldStreet);
-    static final Person oldPerson = new Person(oldName, oldAddress);
+  static final String oldName = "Joe";
+  static final int oldNumber = 10;
+  static final String oldStreet = "Main St";
+  static final Address oldAddress = new Address(oldNumber, oldStreet);
+  static final Person oldPerson = new Person(oldName, oldAddress);
 
-    @Test
-    public final void get() {
-        assertTrue(personNameLens.get(oldPerson).equals(oldName));
-        assertTrue(personNumberLens.get(oldPerson) == oldNumber);
-        assertTrue(personStreetLens.get(oldPerson) == oldStreet);
-    }
+  @Test
+  final void get() {
+    assertTrue(personNameLens.get(oldPerson).equals(oldName));
+    assertTrue(personNumberLens.get(oldPerson) == oldNumber);
+    assertTrue(personStreetLens.get(oldPerson) == oldStreet);
+  }
 
-    @Test
-    public final void setName() {
-        String newName = "Bill";
-        Person p = personNameLens.set(newName).f(oldPerson);
-        assertTrue(p.name.equals(newName));
-        assertTrue(addressEqual.eq(p.address, oldPerson.address));
-    }
+  @Test
+  final void setName() {
+    String newName = "Bill";
+    Person p = personNameLens.set(newName).f(oldPerson);
+    assertTrue(p.name.equals(newName));
+    assertTrue(addressEqual.eq(p.address, oldPerson.address));
+  }
 
-    @Test
-    public final void setNumber() {
-        int newNumber = 20;
-        Person p = personNumberLens.set(newNumber).f(oldPerson);
-        assertTrue(p.name.equals(oldName));
-        assertTrue(p.address.number == newNumber);
-        assertTrue(p.address.street.equals(oldStreet));
-    }
+  @Test
+  final void setNumber() {
+    int newNumber = 20;
+    Person p = personNumberLens.set(newNumber).f(oldPerson);
+    assertTrue(p.name.equals(oldName));
+    assertTrue(p.address.number == newNumber);
+    assertTrue(p.address.street.equals(oldStreet));
+  }
 
-    @Test
-    public final void setStreet() {
-        String newStreet = "First St";
-        Person p = personStreetLens.set(newStreet).f(oldPerson);
-        assertTrue(p.name.equals(oldName));
-        assertTrue(p.address.number == oldPerson.address.number);
-        assertTrue(p.address.street.equals(newStreet));
-    }
+  @Test
+  final void setStreet() {
+    String newStreet = "First St";
+    Person p = personStreetLens.set(newStreet).f(oldPerson);
+    assertTrue(p.name.equals(oldName));
+    assertTrue(p.address.number == oldPerson.address.number);
+    assertTrue(p.address.street.equals(newStreet));
+  }
 
 }

--- a/demo/src/test/java/fj/EmptyTest.java
+++ b/demo/src/test/java/fj/EmptyTest.java
@@ -1,15 +1,15 @@
 package fj;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class EmptyTest {
 
-    @Ignore @Test
-    public void missing() {
-        Assert.fail("not implemented");
+  @Disabled
+  @Test
+  void missing() {
+    Assertions.fail("not implemented");
 
-    }
+  }
 }

--- a/java-core/src/test/java/fj/EmptyTest.java
+++ b/java-core/src/test/java/fj/EmptyTest.java
@@ -1,14 +1,15 @@
 package fj;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class EmptyTest {
 
-    @Ignore @Test
-    public void missing() {
-        Assert.fail("not implemented");
+  @Disabled
+  @Test
+  void missing() {
+    Assertions.fail("not implemented");
 
-    }
+  }
 }

--- a/performance/src/test/java/fj/data/dummy/DummyTest.java
+++ b/performance/src/test/java/fj/data/dummy/DummyTest.java
@@ -1,14 +1,14 @@
 package fj.data.dummy;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DummyTest {
 
-    @Test
-    @Ignore
-    public void test1() {
+  @Test
+  @Disabled
+  void test1() {
 
-    }
+  }
 
 }

--- a/props-core-scalacheck/src/test/scala/fj/FunctionalJavaJUnitTest.java
+++ b/props-core-scalacheck/src/test/scala/fj/FunctionalJavaJUnitTest.java
@@ -1,7 +1,7 @@
 package fj;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created with IntelliJ IDEA.
@@ -12,12 +12,12 @@ import org.junit.Test;
  */
 public class FunctionalJavaJUnitTest {
 
-	@Test
-	public void runScalacheckTests() {
+  @Test
+  void runScalacheckTests() {
 //		System.out.println("Hello world");
-		Assert.assertTrue(true);
+    Assertions.assertTrue(true);
 //		new Tests$().main(null);
-		Tests.main(null);
-	}
+    Tests.main(null);
+  }
 
 }

--- a/props-core/src/test/java/fj/MemoisationTest.java
+++ b/props-core/src/test/java/fj/MemoisationTest.java
@@ -2,7 +2,8 @@ package fj;
 
 import fj.test.Property;
 import fj.test.runner.PropertyTestRunner;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static fj.test.Arbitrary.arbInteger;
@@ -10,79 +11,78 @@ import static fj.test.Arbitrary.arbString;
 import static fj.test.CheckResult.summary;
 import static fj.test.Property.prop;
 import static fj.test.Property.property;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(PropertyTestRunner.class)
 public class MemoisationTest {
 
-    public Property test1() {
-        return property(arbInteger, a -> {
-            P1<Integer> t = P.weakMemo(() -> a);
-            return prop(t._1().equals(t._1())).and(prop(t._1().equals(a)));
-        });
-    }
+  public Property test1() {
+    return property(arbInteger, a -> {
+      P1<Integer> t = P.weakMemo(() -> a);
+      return prop(t._1().equals(t._1())).and(prop(t._1().equals(a)));
+    });
+  }
 
-    public Property test1_hardMemo() {
-        return property(arbString, a -> {
-            P1<String> t = P.hardMemo(() -> new String(a));
-            return prop(t._1() == t._1()).and(prop(t._1().equals(a)));
-        });
-    }
+  public Property test1_hardMemo() {
+    return property(arbString, a -> {
+      P1<String> t = P.hardMemo(() -> new String(a));
+      return prop(t._1() == t._1()).and(prop(t._1().equals(a)));
+    });
+  }
 
-    @Test
-    public Property test2() {
-        return property(arbString, arbString, (a, b) -> {
-            P2<String, String> t = P.lazy(u ->  new String(a), u -> new String(b)).memo();
-            return prop(t._1().equals(t._1()) && t._1().equals(a) && t._2().equals(t._2()) && t._2().equals(b) );
-        });
-    }
+  @Test
+  Property test2() {
+    return property(arbString, arbString, (a, b) -> {
+      P2<String, String> t = P.lazy(u -> new String(a), u -> new String(b)).memo();
+      return prop(t._1().equals(t._1()) && t._1().equals(a) && t._2().equals(t._2()) && t._2().equals(b));
+    });
+  }
 
-    @Test
-    public Property test3() {
-        return property(arbInteger, arbInteger, arbInteger, (a, b, c) -> {
-            P3<Integer, Integer, Integer> t = P.p(a, b, c).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3());
-        });
-    }
+  @Test
+  Property test3() {
+    return property(arbInteger, arbInteger, arbInteger, (a, b, c) -> {
+      P3<Integer, Integer, Integer> t = P.p(a, b, c).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3());
+    });
+  }
 
-    @Test
-    public Property test4() {
-        return property(arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d) -> {
-            P4<Integer, Integer, Integer, Integer> t = P.p(a, b, c, d).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4());
-        });
-    }
+  @Test
+  Property test4() {
+    return property(arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d) -> {
+      P4<Integer, Integer, Integer, Integer> t = P.p(a, b, c, d).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4());
+    });
+  }
 
-    @Test
-    public Property test5() {
-        return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e) -> {
-            P5<Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5());
-        });
-    }
+  @Test
+  Property test5() {
+    return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e) -> {
+      P5<Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5());
+    });
+  }
 
-    @Test
-    public Property test6() {
-        return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f) -> {
-            P6<Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6());
-        });
-    }
+  @Test
+  Property test6() {
+    return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f) -> {
+      P6<Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6());
+    });
+  }
 
-    @Test
-    public Property test7() {
-        return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f, g) -> {
-            P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f, g).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6() && t._7() == t._7());
-        });
-    }
+  @Test
+  Property test7() {
+    return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f, g) -> {
+      P7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f, g).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6() && t._7() == t._7());
+    });
+  }
 
-    @Test
-    public Property test8() {
-        return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f, g, h) -> {
-            P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f, g, h).memo();
-            return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6() && t._7() == t._7() && t._8() == t._8());
-        });
-    }
+  @Test
+  Property test8() {
+    return property(arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, arbInteger, (a, b, c, d, e, f, g, h) -> {
+      P8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> t = P.p(a, b, c, d, e, f, g, h).memo();
+      return prop(t._1() == t._1() && t._2() == t._2() && t._3() == t._3() && t._4() == t._4() && t._5() == t._5() && t._6() == t._6() && t._7() == t._7() && t._8() == t._8());
+    });
+  }
 
 }

--- a/props-core/src/test/java/fj/control/parallel/CheckParModuleTest.java
+++ b/props-core/src/test/java/fj/control/parallel/CheckParModuleTest.java
@@ -11,7 +11,6 @@ import fj.function.Strings;
 import fj.test.Arbitrary;
 import fj.test.Property;
 import fj.test.runner.PropertyTestRunner;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static fj.Equal.stringEqual;
@@ -27,22 +26,22 @@ import static fj.test.Property.property;
 @RunWith(PropertyTestRunner.class)
 public class CheckParModuleTest {
 
-    public Property parFlatMap() {
-        return property(arbStream(arbString), arbParModule(), (str, pm) -> {
-            F<String, Stream<String>> f = s3 -> Stream.stream(s3, Strings.reverse().f(s3));
-            return prop(Equal.streamEqual(stringEqual).eq(str.bind(f), pm.parFlatMap(str, f).claim()));
-        });
-    }
+  public Property parFlatMap() {
+    return property(arbStream(arbString), arbParModule(), (str, pm) -> {
+      F<String, Stream<String>> f = s3 -> Stream.stream(s3, Strings.reverse().f(s3));
+      return prop(Equal.streamEqual(stringEqual).eq(str.bind(f), pm.parFlatMap(str, f).claim()));
+    });
+  }
 
-    public Property parFoldMap() {
-        return property(arbStream(arbString), arbParModule(), (str, pm) -> {
-            F<Stream<String>, P2<Stream<String>, Stream<String>>> chunk = x -> P.p(Stream.stream(x.head()), x.tail()._1());
-            return prop(stringEqual.eq(
-                stringMonoid.sumLeft(str.map(Strings.reverse())),
-                pm.parFoldMap(str, Strings.reverse(), stringMonoid, chunk).claim()
-            ));
-        });
-    }
+  public Property parFoldMap() {
+    return property(arbStream(arbString), arbParModule(), (str, pm) -> {
+      F<Stream<String>, P2<Stream<String>, Stream<String>>> chunk = x -> P.p(Stream.stream(x.head()), x.tail()._1());
+      return prop(stringEqual.eq(
+          stringMonoid.sumLeft(str.map(Strings.reverse())),
+          pm.parFoldMap(str, Strings.reverse(), stringMonoid, chunk).claim()
+      ));
+    });
+  }
 
 
 }

--- a/props-core/src/test/java/fj/data/ReaderTest.java
+++ b/props-core/src/test/java/fj/data/ReaderTest.java
@@ -3,124 +3,125 @@ package fj.data;
 import fj.F;
 import fj.data.test.PropertyAssert;
 import fj.test.*;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.test.Arbitrary.*;
 import static fj.test.Cogen.cogenInteger;
 import static fj.test.Property.prop;
 import static fj.test.Property.property;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 
 public class ReaderTest {
 
-    @Test
-    public void testMap() {
-        // (3 + 8) * 11
-        // example taken from http://learnyouahaskell.com/for-a-few-monads-more
-        int x = Reader.unit((Integer i) -> i + 3).map(i -> i * 5).f(8);
-        assertTrue(x == 55);
-    }
+  @Test
+  void testMap() {
+    // (3 + 8) * 11
+    // example taken from http://learnyouahaskell.com/for-a-few-monads-more
+    int x = Reader.unit((Integer i) -> i + 3).map(i -> i * 5).f(8);
+    assertTrue(x == 55);
+  }
 
-    @Test
-    public void testFlatMap() {
-        // (3 * 2) + (3 + 10)
-        // example taken from http://learnyouahaskell.com/for-a-few-monads-more
-        int y = Reader.unit((Integer i) -> i * 2).flatMap(a -> Reader.unit((Integer i) -> i + 10).map(b -> a + b)).f(3);
+  @Test
+  void testFlatMap() {
+    // (3 * 2) + (3 + 10)
+    // example taken from http://learnyouahaskell.com/for-a-few-monads-more
+    int y = Reader.unit((Integer i) -> i * 2).flatMap(a -> Reader.unit((Integer i) -> i + 10).map(b -> a + b)).f(3);
 //        System.out.println(y); // 19
-        assertTrue(y == 19);
-    }
+    assertTrue(y == 19);
+  }
 
-    @Test
-    public void testMapProp() {
-        Property p = property(
-                arbF(cogenInteger, arbInteger),
-                arbF(cogenInteger, arbInteger),
-                arbInteger,
-                (f, g, i) -> {
-                    int expected = f.map(g).f(i);
+  @Test
+  void testMapProp() {
+    Property p = property(
+        arbF(cogenInteger, arbInteger),
+        arbF(cogenInteger, arbInteger),
+        arbInteger,
+        (f, g, i) -> {
+          int expected = f.map(g).f(i);
 //                    System.out.println(String.format("input: %d, result: %d", i, expected));
-                    return prop(expected == Reader.unit(f).map(g).f(i));
-                });
-        PropertyAssert.assertResult(p);
-    }
+          return prop(expected == Reader.unit(f).map(g).f(i));
+        });
+    PropertyAssert.assertResult(p);
+  }
 
-    @Test
-    public void testFlatMapProp() {
-        Gen<F<Integer, Reader<Integer, Integer>>> a = arbF(cogenInteger, arbReader());
-        Property p = property(
-                arbF(cogenInteger, arbInteger),
-                a,
-                arbInteger,
-                (f, g, i) -> {
-                    int expected = f.bind(j -> g.f(j).getFunction()).f(i);
+  @Test
+  void testFlatMapProp() {
+    Gen<F<Integer, Reader<Integer, Integer>>> a = arbF(cogenInteger, arbReader());
+    Property p = property(
+        arbF(cogenInteger, arbInteger),
+        a,
+        arbInteger,
+        (f, g, i) -> {
+          int expected = f.bind(j -> g.f(j).getFunction()).f(i);
 //              System.out.println(String.format("input: %d, result: %d", i, expected));
-                    return prop(expected == Reader.unit(f).flatMap(g).f(i));
-                }
-        );
-        PropertyAssert.assertResult(p);
-    }
+          return prop(expected == Reader.unit(f).flatMap(g).f(i));
+        }
+    );
+    PropertyAssert.assertResult(p);
+  }
 
-    // Left identity: return a >>= f == f a
-    @Test
-    public void testLeftIdentity() {
-        Property p = Property.property(
-                arbInteger,
-                arbInteger,
-                arbF(cogenInteger, arbReader()),
-                (i, j, f) -> {
-                    int a = Reader.<Integer, Integer>constant(i).flatMap(f).f(j);
-                    int b = f.f(i).f(j);
-                    return prop(a == b);
-                });
-        PropertyAssert.assertResult(p);
-    }
+  // Left identity: return a >>= f == f a
+  @Test
+  void testLeftIdentity() {
+    Property p = Property.property(
+        arbInteger,
+        arbInteger,
+        arbF(cogenInteger, arbReader()),
+        (i, j, f) -> {
+          int a = Reader.<Integer, Integer>constant(i).flatMap(f).f(j);
+          int b = f.f(i).f(j);
+          return prop(a == b);
+        });
+    PropertyAssert.assertResult(p);
+  }
 
-    // Right identity: m >>= return == m
-    @Test
-    public void testRightIdentity() {
-        Property p = Property.property(
-                arbInteger,
-                arbReader(),
-                (i, r2) -> {
-                    return prop(r2.flatMap(a -> Reader.constant(a)).f(i) == r2.f(i));
-                });
-        PropertyAssert.assertResult(p);
-    }
+  // Right identity: m >>= return == m
+  @Test
+  void testRightIdentity() {
+    Property p = Property.property(
+        arbInteger,
+        arbReader(),
+        (i, r2) -> {
+          return prop(r2.flatMap(a -> Reader.constant(a)).f(i) == r2.f(i));
+        });
+    PropertyAssert.assertResult(p);
+  }
 
-    // Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
-    @Test
-    public void testAssociativity() {
-        Property p = Property.property(
-                arbInteger,
-                arbReader(),
-                arbF(cogenInteger, arbReader()),
-                arbF(cogenInteger, arbReader()),
-                (i, r, f, g) -> {
-                    boolean b2 = r.flatMap(f).flatMap(g).f(i) == r.flatMap(x -> f.f(x).flatMap(g)).f(i);
-                    return prop(b2);
-                });
-        PropertyAssert.assertResult(p);
-    }
+  // Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
+  @Test
+  void testAssociativity() {
+    Property p = Property.property(
+        arbInteger,
+        arbReader(),
+        arbF(cogenInteger, arbReader()),
+        arbF(cogenInteger, arbReader()),
+        (i, r, f, g) -> {
+          boolean b2 = r.flatMap(f).flatMap(g).f(i) == r.flatMap(x -> f.f(x).flatMap(g)).f(i);
+          return prop(b2);
+        });
+    PropertyAssert.assertResult(p);
+  }
 
-    @Test
-    public void testAndThen() {
-        final int y = Reader.unit((Integer i) -> i * 2).andThen(i -> i + 10).f(10);
-        assertThat(y, is(30));
-    }
+  @Test
+  void testAndThen() {
+    final int y = Reader.unit((Integer i) -> i * 2).andThen(i -> i + 10).f(10);
+    assertThat(y, is(30));
+  }
 
-    @Test
-    public void testBind() {
-        final int y = Reader.unit((Integer i) -> i * 2)
-                .bind(a -> Reader.unit(i -> a + i + 11)).f(10);
-        assertThat(y, is(41));
-    }
+  @Test
+  void testBind() {
+    final int y = Reader.unit((Integer i) -> i * 2)
+        .bind(a -> Reader.unit(i -> a + i + 11)).f(10);
+    assertThat(y, is(41));
+  }
 
-    public Gen<Reader<Integer, Integer>> arbReader() {
-        return Arbitrary.arbReader(cogenInteger, arbInteger);
-    }
+  public Gen<Reader<Integer, Integer>> arbReader() {
+    return Arbitrary.arbReader(cogenInteger, arbInteger);
+  }
 
 
 }

--- a/props-core/src/test/java/fj/data/TestRngState.java
+++ b/props-core/src/test/java/fj/data/TestRngState.java
@@ -5,8 +5,8 @@ import fj.test.Arbitrary;
 import fj.test.Cogen;
 import fj.test.Gen;
 import fj.test.Property;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static fj.data.Option.some;
 import static fj.data.Stream.unfold;
@@ -19,129 +19,129 @@ import static fj.test.Variant.variant;
 
 public class TestRngState {
 
-	static List<Integer> expected1 = List.list(4,4,2,2,2,5,3,3,1,5);
-	static int size = 10;
-    static final Equal<List<Integer>> listIntEqual = Equal.listEqual(Equal.intEqual);
+  static List<Integer> expected1 = List.list(4, 4, 2, 2, 2, 5, 3, 3, 1, 5);
+  static int size = 10;
+  static final Equal<List<Integer>> listIntEqual = Equal.listEqual(Equal.intEqual);
 
-    static Rng defaultRng() {
-        return new LcgRng(1);
-    }
+  static Rng defaultRng() {
+    return new LcgRng(1);
+  }
 
-    static P2<Rng, Integer> num(Rng r) {
-        return r.range(1, 5);
-    }
+  static P2<Rng, Integer> num(Rng r) {
+    return r.range(1, 5);
+  }
 
-    static State<Rng, Integer> defaultState() {
-        return State.unit(s -> num(s));
-    }
+  static State<Rng, Integer> defaultState() {
+    return State.unit(s -> num(s));
+  }
 
-    static F<State<Rng, Integer>, State<Rng, Integer>> nextState() {
-        return s -> s.mapState(p2 -> num(p2._1()));
-    }
+  static F<State<Rng, Integer>, State<Rng, Integer>> nextState() {
+    return s -> s.mapState(p2 -> num(p2._1()));
+  }
 
-	static P2<Rng, Integer> num(Rng r, int x) {
-		return r.range(x, x + 1);
-	}
+  static P2<Rng, Integer> num(Rng r, int x) {
+    return r.range(x, x + 1);
+  }
 
-	@Test
-    public void testUnfold() {
-        Stream<Integer> s = unfold(r -> some(num(r).swap()), defaultRng());
-		Assert.assertTrue(listIntEqual.eq(s.take(size).toList(), expected1));
-    }
+  @Test
+  void testUnfold() {
+    Stream<Integer> s = unfold(r -> some(num(r).swap()), defaultRng());
+    Assertions.assertTrue(listIntEqual.eq(s.take(size).toList(), expected1));
+  }
 
-    @Test
-    public void testTransitions() {
-		P2<List<State<Rng, Integer>>, State<Rng, Integer>> p = List.replicate(size, nextState()).foldLeft(
-			(P2<List<State<Rng, Integer>>, State<Rng, Integer>> p2, F<State<Rng, Integer>, State<Rng, Integer>> f) -> {
-				State<Rng, Integer> s = f.f(p2._2());
-				return P.p(p2._1().snoc(p2._2()), s);
-			}
-				, P.p(List.nil(),  defaultState())
-		);
-		List<Integer> ints = p._1().map(s -> s.eval(defaultRng()));
-		Assert.assertTrue(listIntEqual.eq(ints, expected1));
-    }
+  @Test
+  void testTransitions() {
+    P2<List<State<Rng, Integer>>, State<Rng, Integer>> p = List.replicate(size, nextState()).foldLeft(
+        (P2<List<State<Rng, Integer>>, State<Rng, Integer>> p2, F<State<Rng, Integer>, State<Rng, Integer>> f) -> {
+          State<Rng, Integer> s = f.f(p2._2());
+          return P.p(p2._1().snoc(p2._2()), s);
+        }
+    , P.p(List.nil(), defaultState())
+    );
+    List<Integer> ints = p._1().map(s -> s.eval(defaultRng()));
+    Assertions.assertTrue(listIntEqual.eq(ints, expected1));
+  }
 
-	@Test
-	public void testSequence() {
-		List<Integer> list = State.sequence(List.replicate(size, defaultState())).eval(defaultRng());
-		Assert.assertTrue(listIntEqual.eq(list, expected1));
-	}
+  @Test
+  void testSequence() {
+    List<Integer> list = State.sequence(List.replicate(size, defaultState())).eval(defaultRng());
+    Assertions.assertTrue(listIntEqual.eq(list, expected1));
+  }
 
-    @Test
-    public void testTraverse() {
-        List<Integer> list = State.traverse(List.range(1, 10), a -> (State.unit((Rng s) -> num(s, a)))).eval(defaultRng());
+  @Test
+  void testTraverse() {
+    List<Integer> list = State.traverse(List.range(1, 10), a -> (State.unit((Rng s) -> num(s, a)))).eval(defaultRng());
 //        System.out.println(list.toString());
-        List<Integer> expected = List.list(1,2,3,5,6,7,7,9,10);
-        Assert.assertTrue(listIntEqual.eq(list, expected));
-    }
+    List<Integer> expected = List.list(1, 2, 3, 5, 6, 7, 7, 9, 10);
+    Assertions.assertTrue(listIntEqual.eq(list, expected));
+  }
 
-    public static Gen<State<LcgRng, Integer>> arbState() {
-        return Arbitrary.arbState(Arbitrary.arbLcgRng(), Cogen.cogenLcgRng(), arbInteger);
-    }
+  public static Gen<State<LcgRng, Integer>> arbState() {
+    return Arbitrary.arbState(Arbitrary.arbLcgRng(), Cogen.cogenLcgRng(), arbInteger);
+  }
 
-    public static Gen<F<LcgRng, P2<LcgRng, Integer>>> arbStateF() {
-        return arbF(Cogen.cogenLcgRng(), arbP2(arbLcgRng(), arbInteger));
-    }
+  public static Gen<F<LcgRng, P2<LcgRng, Integer>>> arbStateF() {
+    return arbF(Cogen.cogenLcgRng(), arbP2(arbLcgRng(), arbInteger));
+  }
 
-    public static Cogen<State<LcgRng, Integer>> cogenState() {
-        return Cogen.cogenState(Arbitrary.arbLcgRng(), (LcgRng s, Integer j) -> (long) (j >= 0 ? 2 * j : -2 * j + 1));
-    }
+  public static Cogen<State<LcgRng, Integer>> cogenState() {
+    return Cogen.cogenState(Arbitrary.arbLcgRng(), (LcgRng s, Integer j) -> (long) (j >= 0 ? 2 * j : -2 * j + 1));
+  }
 
-    public static Gen<F<Integer, State<LcgRng, Integer>>> arbBindable() {
-        return arbF(cogenInteger, arbState());
-    }
+  public static Gen<F<Integer, State<LcgRng, Integer>>> arbBindable() {
+    return arbF(cogenInteger, arbState());
+  }
 
-    // Left identity: return i >>= f == f i
-    @Test
-    public void testLeftIdentity() {
-        Property p = property(
-                arbBindable(),
-                arbInteger,
-                arbLcgRng(),
-                (f, i, r) -> {
-                    int a = State.<LcgRng, Integer>constant(i).flatMap(f).eval(r);
-                    int b = f.f(i).eval(r);
+  // Left identity: return i >>= f == f i
+  @Test
+  void testLeftIdentity() {
+    Property p = property(
+        arbBindable(),
+        arbInteger,
+        arbLcgRng(),
+        (f, i, r) -> {
+          int a = State.<LcgRng, Integer>constant(i).flatMap(f).eval(r);
+          int b = f.f(i).eval(r);
 //                    System.out.println(String.format("a=%d, b=%d", a, b));
-                    return prop(a == b);
-                }
-        );
-        assertResult(p);
-    }
+          return prop(a == b);
+        }
+    );
+    assertResult(p);
+  }
 
 
-    // Right identity: m >>= return == m
-    @Test
-    public void testRightIdentity() {
-        Property p = Property.property(
-                arbState(),
-                arbLcgRng(),
-                (s, r) -> {
-                    int x = s.flatMap(a -> State.constant(a)).eval(r);
-                    int y = s.eval(r);
+  // Right identity: m >>= return == m
+  @Test
+  void testRightIdentity() {
+    Property p = Property.property(
+        arbState(),
+        arbLcgRng(),
+        (s, r) -> {
+          int x = s.flatMap(a -> State.constant(a)).eval(r);
+          int y = s.eval(r);
 //                    System.out.println(String.format("x=%d, y=%d", x, y));
-                    return prop(x == y);
-                }
-        );
-        assertResult(p);
-    }
+          return prop(x == y);
+        }
+    );
+    assertResult(p);
+  }
 
-    // Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
-    @Test
-    public void testAssociativity() {
-        Property p = Property.property(
-                arbState(),
-                arbBindable(),
-                arbBindable(),
-                arbLcgRng(),
-                (s, f, g, r) -> {
-                    int t = s.flatMap(f).flatMap(g).eval(r);
-                    int u = s.flatMap(x -> f.f(x).flatMap(g)).eval(r);
+  // Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
+  @Test
+  void testAssociativity() {
+    Property p = Property.property(
+        arbState(),
+        arbBindable(),
+        arbBindable(),
+        arbLcgRng(),
+        (s, f, g, r) -> {
+          int t = s.flatMap(f).flatMap(g).eval(r);
+          int u = s.flatMap(x -> f.f(x).flatMap(g)).eval(r);
 //                    System.out.println(String.format("x=%d, y=%d", t, u));
-                    return prop(t == u);
-                });
-        assertResult(p);
-    }
+          return prop(t == u);
+        });
+    assertResult(p);
+  }
 
 
 }

--- a/props-core/src/test/java/fj/data/fingertrees/FingerTreeTest.java
+++ b/props-core/src/test/java/fj/data/fingertrees/FingerTreeTest.java
@@ -5,7 +5,8 @@ import fj.P;
 import fj.P2;
 import fj.data.List;
 import fj.data.Option;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Monoid.intAdditionMonoid;
 import static fj.Monoid.intMinMonoid;
@@ -16,84 +17,84 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FingerTreeTest {
 
-    public static final int SIZE = 10;
+  public static final int SIZE = 10;
 
-    @Test
-    public void size() {
-        validateOperations(List.list(-92, 68, 54, -77, -18, 67));
-        validateOperations(List.list(-92, 68, 54, -77, -18, 67, -60, 23, -70, 99, 66, -79, -5));
-    }
+  @Test
+  void size() {
+    validateOperations(List.list(-92, 68, 54, -77, -18, 67));
+    validateOperations(List.list(-92, 68, 54, -77, -18, 67, -60, 23, -70, 99, 66, -79, -5));
+  }
 
-    void validateOperations(List<Integer> list) {
-        FingerTree<Integer, Integer> ft = list.foldLeft(
-            (acc, i) -> acc.snoc(i), FingerTree.<Integer>emptyIntAddition()
-        );
-        assertThat(ft.measure(), equalTo(list.length()));
-        assertThat(ft.foldLeft((s, i) -> s + 1, 0), equalTo(list.length()));
-        assertThat(ft.foldRight((i, s) -> 1 + s, 0), equalTo(list.length()));
-        assertThat(ft.filter(e -> e.equals(-77)).head(), equalTo(-77));
-        assertThat(ft.length(), equalTo(list.length()));
-    }
+  void validateOperations(List<Integer> list) {
+    FingerTree<Integer, Integer> ft = list.foldLeft(
+        (acc, i) -> acc.snoc(i), FingerTree.<Integer>emptyIntAddition()
+    );
+    assertThat(ft.measure(), equalTo(list.length()));
+    assertThat(ft.foldLeft((s, i) -> s + 1, 0), equalTo(list.length()));
+    assertThat(ft.foldRight((i, s) -> 1 + s, 0), equalTo(list.length()));
+    assertThat(ft.filter(e -> e.equals(-77)).head(), equalTo(-77));
+    assertThat(ft.length(), equalTo(list.length()));
+  }
 
-    @Test
-    public void testHeadOption() {
-        assertThat(Empty.emptyIntAddition().headOption(), is(Option.none()));
-        FingerTree<Integer, Integer> ft = new MakeTree<Integer, Integer>(measured(intAdditionMonoid, Function.constant(1)))
-            .single(1);
-        assertThat(ft.headOption(), is(Option.some(1)));
-    }
+  @Test
+  void testHeadOption() {
+    assertThat(Empty.emptyIntAddition().headOption(), is(Option.none()));
+    FingerTree<Integer, Integer> ft = new MakeTree<Integer, Integer>(measured(intAdditionMonoid, Function.constant(1)))
+        .single(1);
+    assertThat(ft.headOption(), is(Option.some(1)));
+  }
 
-    @Test
-    public void testUncons() {
-        assertThat(Empty.emptyIntAddition().uncons(0, (h, t) -> h), is(0));
-        FingerTree<Integer, Integer> ft = new MakeTree<Integer, Integer>(measured(intAdditionMonoid, Function.constant(1)))
-            .single(1);
-        assertThat(ft.uncons(0, (h, t) -> h), is(1));
-    }
+  @Test
+  void testUncons() {
+    assertThat(Empty.emptyIntAddition().uncons(0, (h, t) -> h), is(0));
+    FingerTree<Integer, Integer> ft = new MakeTree<Integer, Integer>(measured(intAdditionMonoid, Function.constant(1)))
+        .single(1);
+    assertThat(ft.uncons(0, (h, t) -> h), is(1));
+  }
 
-    public FingerTree<Integer, Integer> midSeq() {
-        FingerTree<Integer, Integer> ft = FingerTree.emptyIntAddition();
-        return List.range(1, SIZE).foldLeft(ft2 -> i -> ft2.snoc(i), ft);
-    }
+  public FingerTree<Integer, Integer> midSeq() {
+    FingerTree<Integer, Integer> ft = FingerTree.emptyIntAddition();
+    return List.range(1, SIZE).foldLeft(ft2 -> i -> ft2.snoc(i), ft);
+  }
 
-    @Test
-    public void testSeqString() {
-        String actual = midSeq().toString();
-        String expected = "Deep(9 -> One(1 -> 1), Deep(6 -> One(3 -> Node3(3 -> V3(2,3,4))), Empty(), One(3 -> Node3(3 -> V3(5,6,7)))), Two(2 -> V2(8,9)))";
-        assertThat(actual, equalTo(expected));
-    }
+  @Test
+  void testSeqString() {
+    String actual = midSeq().toString();
+    String expected = "Deep(9 -> One(1 -> 1), Deep(6 -> One(3 -> Node3(3 -> V3(2,3,4))), Empty(), One(3 -> Node3(3 -> V3(5,6,7)))), Two(2 -> V2(8,9)))";
+    assertThat(actual, equalTo(expected));
+  }
 
-    public FingerTree<Integer, P2<Integer, Integer>> midPriorityQueue() {
-        FingerTree<Integer, P2<Integer, Integer>> ft = FingerTree.emptyIntMax();
-        return List.range(1, SIZE).foldLeft(ft2 -> i -> {
-            int j = i % 2 == 0 ? 2 * i : i;
-            FingerTree<Integer, P2<Integer, Integer>> ft3 = ft2.snoc(P.p(j, j));
-            return ft3;
-        }, ft);
-    }
+  public FingerTree<Integer, P2<Integer, Integer>> midPriorityQueue() {
+    FingerTree<Integer, P2<Integer, Integer>> ft = FingerTree.emptyIntMax();
+    return List.range(1, SIZE).foldLeft(ft2 -> i -> {
+      int j = i % 2 == 0 ? 2 * i : i;
+      FingerTree<Integer, P2<Integer, Integer>> ft3 = ft2.snoc(P.p(j, j));
+      return ft3;
+    }, ft);
+  }
 
-    @Test
-    public void testQueueString() {
-        String actual = midPriorityQueue().toString();
-        String expected = "Deep(16 -> One(1 -> (1,1)), Deep(12 -> One(8 -> Node3(8 -> V3((4,4),(3,3),(8,8)))), Empty(), One(12 -> Node3(12 -> V3((5,5),(12,12),(7,7))))), Two(16 -> V2((16,16),(9,9))))";
-        assertThat(actual, equalTo(expected));
-    }
+  @Test
+  void testQueueString() {
+    String actual = midPriorityQueue().toString();
+    String expected = "Deep(16 -> One(1 -> (1,1)), Deep(12 -> One(8 -> Node3(8 -> V3((4,4),(3,3),(8,8)))), Empty(), One(12 -> Node3(12 -> V3((5,5),(12,12),(7,7))))), Two(16 -> V2((16,16),(9,9))))";
+    assertThat(actual, equalTo(expected));
+  }
 
-    @Test
-    public void stream() {
-        FingerTree<Integer, Integer> ft = midSeq();
-        assertThat(ft.toStream().toList(), equalTo(List.range(1, SIZE)));
-    }
+  @Test
+  void stream() {
+    FingerTree<Integer, Integer> ft = midSeq();
+    assertThat(ft.toStream().toList(), equalTo(List.range(1, SIZE)));
+  }
 
-    @Test
-    public void split() {
-        int splitPoint = 3;
-        FingerTree<Integer, Integer> ft = FingerTree.emptyIntAddition();
-        FingerTree<Integer, Integer> ft3 = List.range(1, SIZE).foldLeft(ft2 -> i -> ft2.snoc(i), ft);
-        P2<FingerTree<Integer, Integer>, FingerTree<Integer, Integer>> p = ft3.split(v -> v >= splitPoint);
-        assertThat(p._1().toStream().toList(), equalTo(List.range(1, splitPoint)));
-        assertThat(p._2().toStream().toList(), equalTo(List.range(splitPoint, SIZE)));
+  @Test
+  void split() {
+    int splitPoint = 3;
+    FingerTree<Integer, Integer> ft = FingerTree.emptyIntAddition();
+    FingerTree<Integer, Integer> ft3 = List.range(1, SIZE).foldLeft(ft2 -> i -> ft2.snoc(i), ft);
+    P2<FingerTree<Integer, Integer>, FingerTree<Integer, Integer>> p = ft3.split(v -> v >= splitPoint);
+    assertThat(p._1().toStream().toList(), equalTo(List.range(1, splitPoint)));
+    assertThat(p._2().toStream().toList(), equalTo(List.range(splitPoint, SIZE)));
 
-    }
+  }
 
 }

--- a/props-core/src/test/java/fj/data/hamt/BitSetProperties.java
+++ b/props-core/src/test/java/fj/data/hamt/BitSetProperties.java
@@ -12,7 +12,6 @@ import fj.test.Gen;
 import fj.test.Property;
 import fj.test.reflect.CheckParams;
 import fj.test.runner.PropertyTestRunner;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
@@ -35,184 +34,184 @@ import static fj.test.Property.property;
 @CheckParams(maxSize = 10000)
 public class BitSetProperties {
 
-    Property andTest() {
-        return property(arbLong, arbLong, (a, b) -> prop(longBitSet(a).and(longBitSet(b)).longValue() == (a & b)));
-    }
+  Property andTest() {
+    return property(arbLong, arbLong, (a, b) -> prop(longBitSet(a).and(longBitSet(b)).longValue() == (a & b)));
+  }
 
-    Property asStringTest() {
-        return property(arbLong, a -> prop(longBitSet(a).asString().equals(Long.toBinaryString(a))));
-    }
+  Property asStringTest() {
+    return property(arbLong, a -> prop(longBitSet(a).asString().equals(Long.toBinaryString(a))));
+  }
 
-    Property bitsToRightTest() {
-        return property(arbLong, arbBitSetSize, (a, i) ->
-            prop(
-                longBitSet(a).bitsToRight(i) ==
+  Property bitsToRightTest() {
+    return property(arbLong, arbBitSetSize, (a, i) ->
+        prop(
+            longBitSet(a).bitsToRight(i) ==
                 longBitSet(a).toList().reverse().take(i).filter(identity()).length()
         ));
-    }
+  }
 
-    Property longRoundTripTest() {
-        return property(arbNaturalLong, l -> prop(longBitSet(l).longValue() == l));
-    }
+  Property longRoundTripTest() {
+    return property(arbNaturalLong, l -> prop(longBitSet(l).longValue() == l));
+  }
 
-    Property empty() {
-        return prop(BitSet.empty().isEmpty() && BitSet.empty().longValue() == 0);
-    }
+  Property empty() {
+    return prop(BitSet.empty().isEmpty() && BitSet.empty().longValue() == 0);
+  }
 
-    Property generalEmptinessTest() {
-        return property(arbListBoolean, list ->
-                prop(list.dropWhile(Booleans.not).isEmpty() == listBitSet(list).isEmpty())
-        );
-    }
+  Property generalEmptinessTest() {
+    return property(arbListBoolean, list ->
+        prop(list.dropWhile(Booleans.not).isEmpty() == listBitSet(list).isEmpty())
+    );
+  }
 
-    Property foldLeftTest() {
-        return property(arbLong, l -> prop(
-            BitSet.longBitSet(l).toList().dropWhile(b -> !b).foldLeft(
-                    (acc, b) -> acc + 1, 0
-            ) == BitSet.longBitSet(l).bitsUsed()
-        ));
-    }
+  Property foldLeftTest() {
+    return property(arbLong, l -> prop(
+        BitSet.longBitSet(l).toList().dropWhile(b -> !b).foldLeft(
+            (acc, b) -> acc + 1, 0
+        ) == BitSet.longBitSet(l).bitsUsed()
+    ));
+  }
 
-    Property fromListTest() {
-        return property(arbListBoolean, l -> prop(listBitSet(l).toList().equals(l.dropWhile(b -> !b))));
-    }
+  Property fromListTest() {
+    return property(arbListBoolean, l -> prop(listBitSet(l).toList().equals(l.dropWhile(b -> !b))));
+  }
 
-    Property fromStreamTest() {
-        return property(arbListBoolean, l -> prop(listBitSet(l).toStream().toList().equals(l.dropWhile(b -> !b))));
-    }
+  Property fromStreamTest() {
+    return property(arbListBoolean, l -> prop(listBitSet(l).toStream().toList().equals(l.dropWhile(b -> !b))));
+  }
 
-    Property fromLongTest() {
-        return property(arbLong, l -> prop(BitSet.longBitSet(l).longValue() == l));
-    }
+  Property fromLongTest() {
+    return property(arbLong, l -> prop(BitSet.longBitSet(l).longValue() == l));
+  }
 
-    Property fromStringTest() {
-        Gen<String> g = arbListBoolean.map(l -> l.map(b -> Integer.toString(BitSet.toInt(b))).foldLeft((acc, s) -> acc + s, ""));
-        return property(g, (s) -> {
-            boolean zeroLength = s.isEmpty();
-            return Property.implies(!zeroLength, () -> {
-                long x = new BigInteger(s, 2).longValue();
-                long y = BitSet.stringBitSet(s).longValue();
-                return prop(x == y);
-            });
-        });
-    }
+  Property fromStringTest() {
+    Gen<String> g = arbListBoolean.map(l -> l.map(b -> Integer.toString(BitSet.toInt(b))).foldLeft((acc, s) -> acc + s, ""));
+    return property(g, (s) -> {
+      boolean zeroLength = s.isEmpty();
+      return Property.implies(!zeroLength, () -> {
+        long x = new BigInteger(s, 2).longValue();
+        long y = BitSet.stringBitSet(s).longValue();
+        return prop(x == y);
+      });
+    });
+  }
 
-    Gen<List<Boolean>> arbListBoolean = Gen.choose(0, MAX_BIT_SIZE).bind(i -> Gen.sequenceN(i, arbBoolean));
+  Gen<List<Boolean>> arbListBoolean = Gen.choose(0, MAX_BIT_SIZE).bind(i -> Gen.sequenceN(i, arbBoolean));
 
-    Property toListTest() {
-        return property(arbListBoolean, list -> {
-            List<Boolean> expected = list.dropWhile(Booleans.not);
-            List<Boolean> actual = listBitSet(list).toList();
-            return prop(Equal.listEqual(Equal.booleanEqual).eq(expected, actual));
-        });
-    }
+  Property toListTest() {
+    return property(arbListBoolean, list -> {
+      List<Boolean> expected = list.dropWhile(Booleans.not);
+      List<Boolean> actual = listBitSet(list).toList();
+      return prop(Equal.listEqual(Equal.booleanEqual).eq(expected, actual));
+    });
+  }
 
-    Property clearTest() {
-        return property(arbLong, arbBitSetSize, (l, i) ->
-                prop(BitSet.longBitSet(l).clear(i).isSet(i) == false)
-        );
-    }
+  Property clearTest() {
+    return property(arbLong, arbBitSetSize, (l, i) ->
+        prop(BitSet.longBitSet(l).clear(i).isSet(i) == false)
+    );
+  }
 
-    Property bitsUsedTest() {
-        return property(arbListBoolean, list -> prop(
-                    list.dropWhile(b -> !b).length() ==
-                    listBitSet(list).bitsUsed()
-        ));
-    }
+  Property bitsUsedTest() {
+    return property(arbListBoolean, list -> prop(
+        list.dropWhile(b -> !b).length() ==
+            listBitSet(list).bitsUsed()
+    ));
+  }
 
-    Property isSetTest() {
-        return property(arbNaturalLong, Gen.choose(0, MAX_BIT_SIZE),
-                (Long l, Integer i) -> prop(longBitSet(l).isSet(i) == ((l & (1L << i)) != 0))
-        );
-    }
+  Property isSetTest() {
+    return property(arbNaturalLong, Gen.choose(0, MAX_BIT_SIZE),
+        (Long l, Integer i) -> prop(longBitSet(l).isSet(i) == ((l & (1L << i)) != 0))
+    );
+  }
 
-    Property stringBitSet() {
-        return property(arbNaturalLong, l ->
-            prop(BitSet.stringBitSet(BitSet.longBitSet(l).asString()).longValue() == l)
-        );
-    }
+  Property stringBitSet() {
+    return property(arbNaturalLong, l ->
+        prop(BitSet.stringBitSet(BitSet.longBitSet(l).asString()).longValue() == l)
+    );
+  }
 
-    Property notTest() {
-        return property(arbLong, l -> prop(longBitSet(l).not().longValue() == ~l));
-    }
+  Property notTest() {
+    return property(arbLong, l -> prop(longBitSet(l).not().longValue() == ~l));
+  }
 
-    Property orTest() {
-        return property(arbLong, arbLong, (x, y) -> prop(
-                longBitSet(x).or(longBitSet(y)).longValue() == (x | y)
-        ));
-    }
+  Property orTest() {
+    return property(arbLong, arbLong, (x, y) -> prop(
+        longBitSet(x).or(longBitSet(y)).longValue() == (x | y)
+    ));
+  }
 
-    Gen<List<Integer>> bitSetIndices(int n) {
-        return Gen.listOfSorted(Gen.choose(0, MAX_BIT_SIZE - 1), n, Ord.intOrd);
-    }
+  Gen<List<Integer>> bitSetIndices(int n) {
+    return Gen.listOfSorted(Gen.choose(0, MAX_BIT_SIZE - 1), n, Ord.intOrd);
+  }
 
-    Property rangeTest() {
-        return property(arbNaturalLong, bitSetIndices(4), (x, list) -> {
-            int l = list.index(0);
-            int h = list.index(2);
-            int m = Math.max(l, Math.min(list.index(1), h - 1));
-            int vh = list.index(3);
-            
-            BitSet bs1 = longBitSet(x);
-            BitSet bs2 = bs1.range(l, h);
-            if(l==h){
-            	return prop(true);
-            }
-            boolean b =
-            	bs1.isSet(m) == bs2.isSet(m - l) &&
-                bs2.isSet(vh - l) == false;
-            return prop(b);
-        });
-    }
-    
+  Property rangeTest() {
+    return property(arbNaturalLong, bitSetIndices(4), (x, list) -> {
+      int l = list.index(0);
+      int h = list.index(2);
+      int m = Math.max(l, Math.min(list.index(1), h - 1));
+      int vh = list.index(3);
 
-    Property setTest() {
-        return property(arbNaturalLong, arbBitSetSize, (l, i) -> prop(longBitSet(l).set(i).isSet(i)));
-    }
+      BitSet bs1 = longBitSet(x);
+      BitSet bs2 = bs1.range(l, h);
+      if (l == h) {
+        return prop(true);
+      }
+      boolean b =
+          bs1.isSet(m) == bs2.isSet(m - l) &&
+              bs2.isSet(vh - l) == false;
+      return prop(b);
+    });
+  }
 
-    Property setBooleanTest() {
-        return property(arbNaturalLong, arbBitSetSize, arbBoolean, (l, i, b) -> prop(longBitSet(l).set(i, b).isSet(i) == b));
-    }
 
-    Property shiftLeftTest() {
-        return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
-            BitSet bs = longBitSet(l);
-            boolean b = bs.shiftLeft(i).longValue() == (l << i);
-            return impliesBoolean(bs.bitsUsed() + i < MAX_BIT_SIZE, b);
-        });
-    }
+  Property setTest() {
+    return property(arbNaturalLong, arbBitSetSize, (l, i) -> prop(longBitSet(l).set(i).isSet(i)));
+  }
 
-    Property shiftRightTest() {
-        return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
-            return prop(longBitSet(l).shiftRight(i).longValue() == (l >> i));
-        });
-    }
+  Property setBooleanTest() {
+    return property(arbNaturalLong, arbBitSetSize, arbBoolean, (l, i, b) -> prop(longBitSet(l).set(i, b).isSet(i) == b));
+  }
 
-    Property takeLowerTest() {
-        return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
-            return prop(bitSetSequal.eq(longBitSet(l).takeLower(i), longBitSet(l).range(0, i)));
-        });
-    }
+  Property shiftLeftTest() {
+    return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
+      BitSet bs = longBitSet(l);
+      boolean b = bs.shiftLeft(i).longValue() == (l << i);
+      return impliesBoolean(bs.bitsUsed() + i < MAX_BIT_SIZE, b);
+    });
+  }
 
-    Property takeUpperTest() {
-        return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
-            return prop(bitSetSequal.eq(longBitSet(l).takeUpper(i), longBitSet(l).range(MAX_BIT_SIZE, MAX_BIT_SIZE - i)));
-        });
-    }
+  Property shiftRightTest() {
+    return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
+      return prop(longBitSet(l).shiftRight(i).longValue() == (l >> i));
+    });
+  }
 
-    Property toStreamTest() {
-        return property(arbNaturalLong, l -> {
-            return prop(listEqual(booleanEqual).eq(longBitSet(l).toList(), longBitSet(l).toStream().toList()));
-        });
-    }
+  Property takeLowerTest() {
+    return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
+      return prop(bitSetSequal.eq(longBitSet(l).takeLower(i), longBitSet(l).range(0, i)));
+    });
+  }
 
-    Property xorTest() {
-        return property(arbNaturalLong, arbNaturalLong, (a, b) -> {
-            return prop(longBitSet(a).xor(longBitSet(b)).longValue() == (a ^ b));
-        });
-    }
-    static final Gen<Long> arbNaturalLong = Gen.choose(0, Long.MAX_VALUE);
+  Property takeUpperTest() {
+    return property(arbNaturalLong, arbBitSetSize, (l, i) -> {
+      return prop(bitSetSequal.eq(longBitSet(l).takeUpper(i), longBitSet(l).range(MAX_BIT_SIZE, MAX_BIT_SIZE - i)));
+    });
+  }
 
-    static final Gen<Integer> arbBitSetSize = Gen.choose(0, MAX_BIT_SIZE - 1);
+  Property toStreamTest() {
+    return property(arbNaturalLong, l -> {
+      return prop(listEqual(booleanEqual).eq(longBitSet(l).toList(), longBitSet(l).toStream().toList()));
+    });
+  }
+
+  Property xorTest() {
+    return property(arbNaturalLong, arbNaturalLong, (a, b) -> {
+      return prop(longBitSet(a).xor(longBitSet(b)).longValue() == (a ^ b));
+    });
+  }
+  static final Gen<Long> arbNaturalLong = Gen.choose(0, Long.MAX_VALUE);
+
+  static final Gen<Integer> arbBitSetSize = Gen.choose(0, MAX_BIT_SIZE - 1);
 
 }

--- a/quickcheck/src/main/java/fj/data/test/PropertyAssert.java
+++ b/quickcheck/src/main/java/fj/data/test/PropertyAssert.java
@@ -3,17 +3,19 @@ package fj.data.test;
 import fj.Unit;
 import fj.test.CheckResult;
 import fj.test.Property;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.Assertions;
 
 public final class PropertyAssert {
 
-    private PropertyAssert(){}
+  private PropertyAssert() {
+  }
 
-    public static Unit assertResult(Property p) {
-        CheckResult cr = p.check();
-        CheckResult.summary.println(cr);
-        Assert.assertTrue(cr.isExhausted() || cr.isPassed() || cr.isProven());
-        return Unit.unit();
-    }
+  public static Unit assertResult(Property p) {
+    CheckResult cr = p.check();
+    CheckResult.summary.println(cr);
+    Assertions.assertTrue(cr.isExhausted() || cr.isPassed() || cr.isProven());
+    return Unit.unit();
+  }
 
 }

--- a/quickcheck/src/test/java/fj/data/test/TestCheck.java
+++ b/quickcheck/src/test/java/fj/data/test/TestCheck.java
@@ -3,28 +3,31 @@ package fj.data.test;
 import fj.test.CheckResult;
 import fj.test.Gen;
 import fj.test.Property;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static fj.test.Property.prop;
 import static fj.test.Property.property;
-import static org.junit.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCheck {
 
-	@Test(timeout=5000 /*ms*/)
-	public void testExceptionsThrownFromGeneratorsArePropagated() {
-		Gen<Integer> failingGen = Gen.value(0).map((i) -> {
-			throw new RuntimeException("test failure");
-		});
+  @Test
+  @Timeout(5000)
+  void testExceptionsThrownFromGeneratorsArePropagated() {
+    Gen<Integer> failingGen = Gen.value(0).map((i) -> {
+      throw new RuntimeException("test failure");
+    });
 
-		Property p = property(failingGen, (Integer i) -> prop(i == 0));
+    Property p = property(failingGen, (Integer i) -> prop(i == 0));
 
-		CheckResult res = p.check(
-			1, /*minSuccessful*/
-			0, /*maxDiscarded*/
-			0, /*minSize*/
-			1 /*maxSize*/
-		);
-		assertTrue("Exception not propagated!", res.isGenException());
-	}
+    CheckResult res = p.check(
+        1, /*minSuccessful*/
+        0, /*maxDiscarded*/
+        0, /*minSize*/
+        1 /*maxSize*/
+    );
+    assertTrue(res.isGenException(), "Exception not propagated!");
+  }
 }

--- a/quickcheck/src/test/java/fj/data/test/TestNull.java
+++ b/quickcheck/src/test/java/fj/data/test/TestNull.java
@@ -3,17 +3,18 @@ package fj.data.test;
 import fj.test.CheckResult;
 import fj.test.Gen;
 import fj.test.Property;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.test.Property.prop;
 import static fj.test.Property.property;
 
 public class TestNull {
 
-	@Test
-	public void testShowNullParameters() {
-		Property p = property(Gen.value(null), (Integer i) -> prop(i != null));
-		CheckResult.summary.println(p.check());
-	}
+  @Test
+  void testShowNullParameters() {
+    Property p = property(Gen.value(null), (Integer i) -> prop(i != null));
+    CheckResult.summary.println(p.check());
+  }
 
 }

--- a/quickcheck/src/test/java/fj/test/GenTest.java
+++ b/quickcheck/src/test/java/fj/test/GenTest.java
@@ -7,7 +7,8 @@ import fj.data.Option;
 import fj.data.Stream;
 import fj.data.Validation;
 import fj.function.Effect1;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.Ord.charOrd;
 import static fj.data.List.list;
@@ -25,21 +26,22 @@ import static fj.test.Gen.sequence;
 import static fj.test.Gen.streamOf;
 import static fj.test.Gen.wordOf;
 import static fj.test.Rand.standard;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class GenTest {
 
   private static final List<Character> AS = list('A', 'B', 'C');
 
   @Test
-  public void testCombinationOf_none() {
+  void testCombinationOf_none() {
     Gen<List<Character>> instance = combinationOf(0, AS);
     testPick(100, instance, actual -> assertTrue(actual.isEmpty()));
   }
 
   @Test
-  public void testCombinationOf_one() {
+  void testCombinationOf_one() {
     Gen<List<Character>> instance = combinationOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
@@ -48,7 +50,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testCombinationOf_two() {
+  void testCombinationOf_two() {
     Gen<List<Character>> instance = combinationOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
@@ -58,7 +60,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testCombinationOf_three() {
+  void testCombinationOf_three() {
     Gen<List<Character>> instance = combinationOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
@@ -68,13 +70,13 @@ public final class GenTest {
   }
 
   @Test
-  public void testSelectionOf_none() {
+  void testSelectionOf_none() {
     Gen<List<Character>> instance = selectionOf(0, AS);
     testPick(100, instance, actual -> assertTrue(actual.isEmpty()));
   }
 
   @Test
-  public void testSelectionOf_one() {
+  void testSelectionOf_one() {
     Gen<List<Character>> instance = selectionOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
@@ -83,7 +85,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testSelectionOf_two() {
+  void testSelectionOf_two() {
     Gen<List<Character>> instance = selectionOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
@@ -93,7 +95,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testSelectionOf_three() {
+  void testSelectionOf_three() {
     Gen<List<Character>> instance = selectionOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
@@ -103,7 +105,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testSelectionOf_four() {
+  void testSelectionOf_four() {
     Gen<List<Character>> instance = selectionOf(4, AS);
     testPick(100, instance, actual -> {
       assertEquals(4, actual.length());
@@ -113,13 +115,13 @@ public final class GenTest {
   }
 
   @Test
-  public void testPermutationOf_none() {
+  void testPermutationOf_none() {
     Gen<List<Character>> instance = permutationOf(0, AS);
     testPick(100, instance, actual -> assertTrue(actual.isEmpty()));
   }
 
   @Test
-  public void testPermutationOf_one() {
+  void testPermutationOf_one() {
     Gen<List<Character>> instance = permutationOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
@@ -128,7 +130,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testPermutationOf_two() {
+  void testPermutationOf_two() {
     Gen<List<Character>> instance = combinationOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
@@ -137,7 +139,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testPermutationOf_three() {
+  void testPermutationOf_three() {
     Gen<List<Character>> instance = permutationOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
@@ -147,13 +149,13 @@ public final class GenTest {
   }
 
   @Test
-  public void testWordOf_none() {
+  void testWordOf_none() {
     Gen<List<Character>> instance = wordOf(0, AS);
     testPick(100, instance, actual -> assertTrue(actual.isEmpty()));
   }
 
   @Test
-  public void testWordOf_one() {
+  void testWordOf_one() {
     Gen<List<Character>> instance = wordOf(1, AS);
     testPick(100, instance, actual -> {
       assertEquals(1, actual.length());
@@ -162,7 +164,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testWordOf_two() {
+  void testWordOf_two() {
     Gen<List<Character>> instance = wordOf(2, AS);
     testPick(100, instance, actual -> {
       assertEquals(2, actual.length());
@@ -171,7 +173,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testWordOf_three() {
+  void testWordOf_three() {
     Gen<List<Character>> instance = wordOf(3, AS);
     testPick(100, instance, actual -> {
       assertEquals(3, actual.length());
@@ -180,7 +182,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testWordOf_four() {
+  void testWordOf_four() {
     Gen<List<Character>> instance = wordOf(4, AS);
     testPick(100, instance, actual -> {
       assertEquals(4, actual.length());
@@ -189,7 +191,7 @@ public final class GenTest {
   }
 
   @Test
-  public void testStreamOf() {
+  void testStreamOf() {
     final Gen<Stream<Character>> instance = streamOf(pickOne(AS));
     testPick(100, instance.map(stream -> stream.take(4).toList()), actual -> {
       assertEquals(4, actual.length());
@@ -198,9 +200,9 @@ public final class GenTest {
   }
 
   @Test
-  public void testSequenceValidation() {
+  void testSequenceValidation() {
     final Gen<List<Validation<NonEmptyList<Exception>, Character>>> success = listOf(sequence(success(pickOne(AS))), 4);
-    testPick(100, success, list -> assertEquals(list.length(),somes(list.map(v -> Option.sequence(v.map(c -> AS.elementIndex(Equal.anyEqual(), c))))).length()));
+    testPick(100, success, list -> assertEquals(list.length(), somes(list.map(v -> Option.sequence(v.map(c -> AS.elementIndex(Equal.anyEqual(), c))))).length()));
 
     final Gen<List<Validation<NonEmptyList<Exception>, Gen<Character>>>> failure = listOf(sequence(fail(nel(new Exception()))), 4);
     testPick(100, failure, list -> assertTrue(list.forall(a -> a.isFail())));

--- a/quickcheck/src/test/java/fj/test/TestBool.java
+++ b/quickcheck/src/test/java/fj/test/TestBool.java
@@ -1,7 +1,8 @@
 package fj.test;
 
 import fj.data.test.PropertyAssert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static fj.test.Arbitrary.arbBoolean;
 import static fj.test.Bool.bool;
@@ -9,10 +10,10 @@ import static fj.test.Property.property;
 
 public class TestBool {
 
-    @Test
-    public void testBool() {
-        final Property p = property(arbBoolean, arbBoolean, (m1, m2) -> bool(m1.equals(m2))
-                .implies(m1 == m2));
-        PropertyAssert.assertResult(p);
-    }
+  @Test
+  void testBool() {
+    final Property p = property(arbBoolean, arbBoolean, (m1, m2) -> bool(m1.equals(m2))
+        .implies(m1 == m2));
+    PropertyAssert.assertResult(p);
+  }
 }

--- a/quickcheck/src/test/java/fj/test/TestRand.java
+++ b/quickcheck/src/test/java/fj/test/TestRand.java
@@ -4,25 +4,25 @@ import fj.Equal;
 import fj.Ord;
 import fj.data.List;
 import fj.data.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRand {
 
-    @Test
-    public void testRandLowHighInclusive() {
-        int min = 5;
-        int max = 10;
-        int n = 100;
-        Stream<Integer> s = Stream.range(0, n).map(i -> Rand.standard.choose(min, max)).sort(Ord.intOrd);
+  @Test
+  void testRandLowHighInclusive() {
+    int min = 5;
+    int max = 10;
+    int n = 100;
+    Stream<Integer> s = Stream.range(0, n).map(i -> Rand.standard.choose(min, max)).sort(Ord.intOrd);
 //        System.out.println(s.toList());
-        assertTrue(s.head() == min && s.last() == max);
-    }
+    assertTrue(s.head() == min && s.last() == max);
+  }
 
   @Test
-  public void testReseed() {
+  void testReseed() {
     Rand rand1 = Rand.standard.reseed(42);
     List<Integer> s1 =
         List.range(0, 10).map(i -> rand1.choose(Integer.MIN_VALUE, Integer.MAX_VALUE));
@@ -32,7 +32,7 @@ public class TestRand {
         List.range(0, 10).map(i -> rand2.choose(Integer.MIN_VALUE, Integer.MAX_VALUE));
 
     assertTrue(s1.zip(s2).forall(p -> p._1().equals(p._2())));
-    Assert.assertFalse(s1.allEqual(Equal.intEqual));
+    Assertions.assertFalse(s1.allEqual(Equal.intEqual));
   }
 
 }


### PR DESCRIPTION
Refactors all tests to use Junit 5 instead of Junit 4.

Also brings all files changed into sync with the prevailing format of the codebase which seems to be a two space indent.

Use this link to re-run the recipe: https://public.moderne.io/recipes/builder/nEvzN